### PR TITLE
add preview for event creation

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -33,6 +33,10 @@ class EventsController < ApplicationController
     @event = Event.new
   end
 
+  def preview
+    @event = Event.new(event_params)
+  end
+
   def create
     @event = Event.new(event_params)
  

--- a/app/views/events/_event.html.erb
+++ b/app/views/events/_event.html.erb
@@ -1,0 +1,19 @@
+<p><%= link_to 'Home', root_path %> > <%= link_to 'Events', events_path %> > <%= @event.name %></p>
+
+<h1><%= @event.name %></h1>
+
+<p>
+  <strong>Description:</strong>
+  <%= @event.description %>
+</p>
+
+<p>
+  <strong>Date:</strong>
+  <%= @event.start_date %>
+
+  <% unless @event.start_date == @event.end_date %>
+    <strong>to</strong>
+    <%= @event.end_date %>
+  <% end %>
+</p>
+

--- a/app/views/events/new.html.erb
+++ b/app/views/events/new.html.erb
@@ -5,7 +5,7 @@
 <% if @event.errors.any? %>
   <div class="error">
     <h2><%= pluralize(@event.errors.count, "error") %> prohibited this event from being saved:</h2>
- 
+
     <ul>
     <% @event.errors.full_messages.each do |msg| %>
       <li><%= msg %></li>
@@ -14,7 +14,7 @@
   </div>
 <% end %>
 
-<%= form_for :event, url: events_path do |f| %>
+<%= form_for :event, url: event_preview_path do |f| %>
   <p class="description">Please fill out this form. Unless otherwise specified, all fields are required.</p>
   <p>Event Details:</p>
   <div class="form_field">

--- a/app/views/events/new.html.erb
+++ b/app/views/events/new.html.erb
@@ -84,7 +84,7 @@
 
   <div class="form_field">
     <p>
-      <%= f.submit("Submit New Event") %>
+      <%= f.submit("Preview Event") %>
     </p>
   </div><br>
 <% end %>

--- a/app/views/events/preview.html.erb
+++ b/app/views/events/preview.html.erb
@@ -1,0 +1,20 @@
+<h1>This is a preview</h1>
+
+<%= render :partial => "events/event" %>
+
+<a href="javascript:history.back()">Go back to edit to make changes</a>
+
+<%= form_for @event, url: events_path do |f| %>
+
+
+      <%= f.hidden_field :name %>
+      <%= f.hidden_field :start_date %>
+      <%= f.hidden_field :end_date %>
+      <%= f.hidden_field :description %>
+      <%= f.hidden_field :organizer_name %>
+      <%= f.hidden_field :organizer_email %>
+      <%= f.hidden_field :organizer_email_confirmation %>
+      <%= f.submit("Submit New Event") %>
+
+<% end %>
+

--- a/app/views/events/preview.html.erb
+++ b/app/views/events/preview.html.erb
@@ -1,20 +1,22 @@
 <h1>This is a preview</h1>
 
 <%= render :partial => "events/event" %>
-
-<a href="javascript:history.back()">Go back to edit to make changes</a>
+<p><strong>Organizer Name:</strong>
+<%=@event.organizer_name%> (not visible to the public)</p>
+<p><strong>Organizer Email:</strong>
+<%=@event.organizer_email%> (not visible to the public)</p>
 
 <%= form_for @event, url: events_path do |f| %>
-
-
-      <%= f.hidden_field :name %>
-      <%= f.hidden_field :start_date %>
-      <%= f.hidden_field :end_date %>
-      <%= f.hidden_field :description %>
-      <%= f.hidden_field :organizer_name %>
-      <%= f.hidden_field :organizer_email %>
-      <%= f.hidden_field :organizer_email_confirmation %>
-      <%= f.submit("Submit New Event") %>
-
+  <%= f.hidden_field :name %>
+  <%= f.hidden_field :start_date %>
+  <%= f.hidden_field :end_date %>
+  <%= f.hidden_field :description %>
+  <%= f.hidden_field :organizer_name %>
+  <%= f.hidden_field :organizer_email %>
+  <%= f.hidden_field :organizer_email_confirmation %>
+  <div class="form_field">
+    <a class="button" href="javascript:history.back()">Edit</a>
+  <%= f.submit("Submit the event") %>
+  </div>
 <% end %>
 

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -1,21 +1,6 @@
-<p><%= link_to 'Home', root_path %> > <%= link_to 'Events', events_path %> > <%= @event.name %></p>
 
-<h1><%= @event.name %></h1>
- 
-<p>
-  <strong>Description:</strong>
-  <%= @event.description %>
-</p>
 
-<p>
-  <strong>Date:</strong>
-  <%= @event.start_date %>
-
-  <% unless @event.start_date == @event.end_date %>
-    <strong>to</strong>
-    <%= @event.end_date %>
-  <% end %>
-</p>
+<%= render :partial => "events/event" %>
 
 <% if @event.open? %>
   <%= link_to 'Apply', new_event_application_path(params[:id]), class:'button' %><br>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,7 @@ Rails.application.routes.draw do
   get '/past_events', to: 'events#index_past', as: :past_events
   get '/admin', to: 'events#admin_index'
   get '/events/:id/admin', to: 'events#admin_show', as: :event_admin
+  post '/events/preview', to: 'events#preview', as: :event_preview
    #The priority is based upon order of creation: first created -> highest priority.
   # See how all your routes lay out with "rake routes".
 


### PR DESCRIPTION
Issue #56 
We split the event creation into preview and submit, because the submitter can't edit once it is final. 

- create "preview" controller action
- set route for preview
- create partial (so you can reuse the show-view in the preview-view)
- change buttons according to that
- added organizer's information to preview