### PR TITLE
add missing form field submit to events#edit

### DIFF
--- a/app/views/events/edit.html.erb
+++ b/app/views/events/edit.html.erb
@@ -5,7 +5,7 @@
 <% if @event.errors.any? %>
   <div class="error">
     <h2><%= pluralize(@event.errors.count, "error") %> prohibited this event from being updated:</h2>
- 
+
     <ul>
     <% @event.errors.full_messages.each do |msg| %>
       <li><%= msg %></li>
@@ -16,4 +16,10 @@
 
 <%= form_for @event, url: event_path(@event), method: :put do |f| %>
   <%= render partial: "form", locals: {f: f} %>
+
+  <div class="form_field">
+    <p>
+      <%= f.submit("Edit Event") %>
+    </p>
+  </div>
 <% end %>


### PR DESCRIPTION
I accidentally deleted the submit button in the edit view for events when I did the form partial. 
I put it there again. Now you can submit the changes.

Issue #88 