### PR TITLE
Remove questions and answers columns from events and applications tables

### DIFF
--- a/app/controllers/applications_controller.rb
+++ b/app/controllers/applications_controller.rb
@@ -22,7 +22,7 @@ class ApplicationsController < ApplicationController
 
   private
     def application_params
-      params.require(:application).permit(:name, :email, :email_confirmation, :answer_1, :answer_2, :answer_3)
+      params.require(:application).permit(:name, :email, :email_confirmation)
     end
 
     def get_event

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -71,7 +71,7 @@ class EventsController < ApplicationController
 
   private
     def event_params
-      params.require(:event).permit(:organizer_name, :organizer_email, :organizer_email_confirmation, :description, :name, :start_date, :end_date, :question_1, :question_2, :question_3, :approved, :ticket_funded, :accommodation_funded, :travel_funded, :deadline, :number_of_tickets, :website, :code_of_conduct, :city, :country)
+      params.require(:event).permit(:organizer_name, :organizer_email, :organizer_email_confirmation, :description, :name, :start_date, :end_date, :ticket_funded, :accommodation_funded, :travel_funded, :deadline, :number_of_tickets, :website, :code_of_conduct, :city, :country)
     end
 
     def get_event

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -71,7 +71,7 @@ class EventsController < ApplicationController
 
   private
     def event_params
-      params.require(:event).permit(:organizer_name, :organizer_email, :organizer_email_confirmation, :description, :name, :start_date, :end_date, :ticket_funded, :accommodation_funded, :travel_funded, :deadline, :number_of_tickets, :website, :code_of_conduct, :city, :country)
+      params.require(:event).permit(:organizer_name, :organizer_email, :organizer_email_confirmation, :description, :name, :start_date, :end_date, :approved, :ticket_funded, :accommodation_funded, :travel_funded, :deadline, :number_of_tickets, :website, :code_of_conduct, :city, :country)
     end
 
     def get_event

--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -3,18 +3,5 @@ class Application < ActiveRecord::Base
   validates :name, presence: true
   validates :email, presence: true, confirmation: true, format: { with: /.+@.+\..+/ }
   validates :email_confirmation, presence: true
-  validate :presence_of_questions
-
-  def presence_of_questions
-    if event.question_1.present? && answer_1.blank?
-      errors.add(:answer_1, "can`t be blank")
-    end
-    if event.question_2.present? && answer_2.blank?
-      errors.add(:answer_2, "can`t be blank")
-    end
-    if event.question_3.present? && answer_3.blank?
-      errors.add(:answer_3, "can`t be blank")
-    end
-  end
 
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -31,9 +31,9 @@ class Event < ActiveRecord::Base
 
   def to_csv
     CSV.generate do |csv|
-      csv << ["name", "email", question_1, question_2, question_3]
+      csv << ["name", "email"]
       applications.each do |application|
-        csv << [application.name, application.email, application.answer_1, application.answer_2, application.answer_3]
+        csv << [application.name, application.email]
       end
     end
   end

--- a/db/migrate/20151213171240_remove_question_and_answer_columns_from_events_and_applications.rb
+++ b/db/migrate/20151213171240_remove_question_and_answer_columns_from_events_and_applications.rb
@@ -1,0 +1,11 @@
+class RemoveQuestionAndAnswerColumnsFromEventsAndApplications < ActiveRecord::Migration
+  def change
+  	remove_column :events, :question_1
+  	remove_column :events, :question_2
+  	remove_column :events, :question_3
+
+  	remove_column :applications, :answer_1
+  	remove_column :applications, :answer_2
+  	remove_column :applications, :answer_3
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151028145014) do
+ActiveRecord::Schema.define(version: 20151213171240) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -22,9 +22,6 @@ ActiveRecord::Schema.define(version: 20151028145014) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer  "event_id"
-    t.text     "answer_1"
-    t.text     "answer_2"
-    t.text     "answer_3"
   end
 
   add_index "applications", ["event_id"], name: "index_applications_on_event_id", using: :btree
@@ -35,9 +32,6 @@ ActiveRecord::Schema.define(version: 20151028145014) do
     t.text     "description"
     t.text     "name"
     t.date     "start_date"
-    t.text     "question_1"
-    t.text     "question_2"
-    t.text     "question_3"
     t.datetime "created_at",                           null: false
     t.datetime "updated_at",                           null: false
     t.date     "end_date"

--- a/test/controllers/applications_controller_test.rb
+++ b/test/controllers/applications_controller_test.rb
@@ -43,10 +43,7 @@ class ApplicationsControllerTest < ActionController::TestCase
                       name: 'Joe',
                       email: 'joe@test.com',
                       email_confirmation: 'joe@test.com',
-                      event: event,
-                      answer_1: 'Hi',
-                      answer_2: 'Hi',
-                      answer_3: 'Hi'
+                      event: event
                     }
 
       assert_redirected_to event

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -38,10 +38,7 @@ class ActiveSupport::TestCase
       name: 'Joe',
       email: 'joe@test.com',
       email_confirmation: 'joe@test.com',
-      event: event,
-      answer_1: 'Hi',
-      answer_2: 'Hi',
-      answer_3: 'Hi'
+      event: event
     }
     application_params = defaults.merge(application_params)
     Application.create!(application_params)


### PR DESCRIPTION
- Write and run migration
- Delete all code that references questions and answers

- Remember to run rake db:migrate

#84