### PR TITLE
Add simplecov gem...

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@
 
 # Ignore Apple created files
 .DS_Store
+
+# Ignore test coverage results (--> simplecov gem)
+coverage

--- a/Gemfile
+++ b/Gemfile
@@ -48,4 +48,6 @@ group :development, :test do
   gem 'pry'
 end
 
+gem 'simplecov', require: false, group: :test
+
 gem 'tzinfo-data', platforms: [:mingw, :mswin]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -57,6 +57,7 @@ GEM
     date_validator (0.8.1)
       activemodel
     debug_inspector (0.0.2)
+    docile (1.1.5)
     erubis (2.7.0)
     execjs (2.5.2)
     globalid (0.3.5)
@@ -89,6 +90,11 @@ GEM
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
+    pry (0.10.1-x86-mingw32)
+      coderay (~> 1.1.0)
+      method_source (~> 0.8.1)
+      slop (~> 3.4)
+      win32console (~> 1.3)
     rack (1.6.4)
     rack-test (0.6.3)
       rack (>= 1.0)
@@ -129,6 +135,11 @@ GEM
     sdoc (0.4.1)
       json (~> 1.7, >= 1.7.7)
       rdoc (~> 4.0)
+    simplecov (0.11.1)
+      docile (~> 1.1.0)
+      json (~> 1.8)
+      simplecov-html (~> 0.10.0)
+    simplecov-html (0.10.0)
     slop (3.6.0)
     spring (1.3.6)
     sprockets (3.2.0)
@@ -154,6 +165,7 @@ GEM
       binding_of_caller (>= 0.7.2)
       railties (>= 4.0)
       sprockets-rails (>= 2.0, < 4.0)
+    win32console (1.3.2-x86-mingw32)
 
 PLATFORMS
   ruby
@@ -171,8 +183,12 @@ DEPENDENCIES
   rails (= 4.2.2)
   sass-rails (~> 5.0)
   sdoc (~> 0.4.0)
+  simplecov
   spring
   turbolinks
   tzinfo-data
   uglifier (>= 1.3.0)
   web-console (~> 2.0)
+
+BUNDLED WITH
+   1.10.6

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -2,7 +2,7 @@
 # are run and what doesn't: Run your tests, open up coverage/index.html
 # in your browser and check out what you've missed so far.
 require 'simplecov'
-SimpleCov.start
+SimpleCov.start 'rails'
 
 ENV['RAILS_ENV'] ||= 'test'
 require File.expand_path('../../config/environment', __FILE__)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,3 +1,9 @@
+# Use simplecov gem to track what code gets executed when tests
+# are run and what doesn't: Run your tests, open up coverage/index.html
+# in your browser and check out what you've missed so far.
+require 'simplecov'
+SimpleCov.start
+
 ENV['RAILS_ENV'] ||= 'test'
 require File.expand_path('../../config/environment', __FILE__)
 require 'rails/test_help'


### PR DESCRIPTION
… to track what parts of the code are executed when tests are run and what parts are not. This does not say anything about the quality of the tests, but can be useful to quickly check what code is not covered by tests at all so far.

(Remember to run 'bundle'.)

To check the test coverage:
- run the tests
- open coverage/index.html in a browser window, either by
a) navigating to the file via your operating system's GUI and right-cklicking on the file, or by
b) entering the path to the file in the browser's URL field, in my case: file:///home/me/Desktop/rubymonsters/diversity_ticketing/coverage/index.html

This is what it looks like right now:
![screenshot from 2015-12-22 01 00 16](https://cloud.githubusercontent.com/assets/11508063/11944924/7e1233c6-a84a-11e5-87d5-33fb5cba4299.png)
