### PR TITLE
fix missing hidden field in preview and show directions in views

### DIFF
--- a/app/views/events/_event.html.erb
+++ b/app/views/events/_event.html.erb
@@ -40,6 +40,11 @@
   <h2 class="box-title">Application Details</h2>
 
   <div class="detail-pair">
+    <strong>Directions for Applicants</strong>
+    <%= @event.applicant_directions %>
+  </div>
+
+  <div class="detail-pair">
     <strong>Deadline for applications</strong>
     <%= @event.deadline %>
   </div>

--- a/app/views/events/preview.html.erb
+++ b/app/views/events/preview.html.erb
@@ -27,6 +27,7 @@
   <%= f.hidden_field :code_of_conduct %>
   <%= f.hidden_field :city %>
   <%= f.hidden_field :country %>
+  <%= f.hidden_field :applicant_directions %>
   <%= f.hidden_field :deadline %>
   <%= f.hidden_field :number_of_tickets %>
   <%= f.hidden_field :ticket_funded %>


### PR DESCRIPTION
Issue #159 

We missed something yesterday:
Directions for applicants doesn't get saved, because the hidden field in preview is missing. (You can save it when you Edit the event.)
It should also show the content (because this is a partial it will show in preview, show and admin_show).
