### PR TITLE
enable markdown for event description with markdownizer gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,6 +26,8 @@ gem 'sdoc', '~> 0.4.0', group: :doc
 
 gem 'date_validator'
 
+gem 'markdownizer'
+
 # Use ActiveModel has_secure_password
 # gem 'bcrypt', '~> 3.1.7'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -75,6 +75,10 @@ GEM
       nokogiri (>= 1.5.9)
     mail (2.6.3)
       mime-types (>= 1.16, < 3)
+    markdownizer (0.3.7)
+      activerecord (>= 3.0.3)
+      coderay
+      rdiscount
     method_source (0.8.2)
     mime-types (2.99)
     mini_portile2 (2.0.0)
@@ -118,6 +122,7 @@ GEM
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
     rake (10.5.0)
+    rdiscount (2.1.8)
     rdoc (4.2.1)
       json (~> 1.4)
     sass (3.4.21)
@@ -173,6 +178,7 @@ DEPENDENCIES
   date_validator
   jbuilder (~> 2.0)
   jquery-rails
+  markdownizer
   pg
   pry
   rails (= 4.2.5.1)
@@ -186,4 +192,4 @@ DEPENDENCIES
   web-console (~> 2.0)
 
 BUNDLED WITH
-   1.10.6
+   1.11.2

--- a/app/assets/stylesheets/form.scss
+++ b/app/assets/stylesheets/form.scss
@@ -44,6 +44,10 @@ textarea {
   border-radius: 2px;
 }
 
+textarea[name="event[description]"] {
+  height: 200px;
+}
+
 .field_with_errors {
 
   label {

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -9,6 +9,8 @@ class Event < ActiveRecord::Base
   validates :website, :code_of_conduct, format: { with: /(http|https):\/\/.+\..+/ }
   validates :number_of_tickets, numericality: { only_integer: true, greater_than_or_equal_to: 1 }, presence: true
 
+  markdownize! :description
+
   def self.approved
     where(approved: true)
   end

--- a/app/views/events/_event.html.erb
+++ b/app/views/events/_event.html.erb
@@ -32,7 +32,7 @@
 
 <div class="detail-pair">
   <strong>Description</strong>
-  <%= @event.description %>
+  <%= raw @event.rendered_description %>
 </div>
 </section>
 

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -25,7 +25,7 @@
   <%= f.form_field :date_field, :start_date, 'From', class: ['left'], placeholder: "dd.mm.yyyy" %>
   <%= f.form_field :date_field, :end_date, 'To', class: ['right'], placeholder: "dd.mm.yyyy" %>
 
-  <%= f.form_field :text_area, :description, 'Description' %>
+  <%= f.form_field :text_area, :description, 'Description (Markdown supported)' %>
 </section>
 
 

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -1,7 +1,7 @@
 <% @events.each do |event| %>
   <div class="box event">
     <h3><%= link_to event.name, event_path(:id => event.id) %></h3>
-    <p><%= event.description %></p>
+    <p><%= raw event.rendered_description %></p>
     <%= link_to 'Apply', new_event_application_path(:event_id => event.id), class:'btn btn-save' %>
   </div>
 <% end %>

--- a/app/views/events/index_past.html.erb
+++ b/app/views/events/index_past.html.erb
@@ -2,7 +2,7 @@
 <% @events.each do |event| %>
   <div class="event">
     <h3><%= link_to event.name, event_path(:id => event.id) %></h3>
-    <p><%= event.description %></p>
+    <p><%= raw event.rendered_description %></p>
   </div>
 <% end %>
 

--- a/db/migrate/20160216172132_add_rendered_description_to_event.rb
+++ b/db/migrate/20160216172132_add_rendered_description_to_event.rb
@@ -1,0 +1,5 @@
+class AddRenderedDescriptionToEvent < ActiveRecord::Migration
+  def change
+    add_column :events, :rendered_description, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160212104941) do
+ActiveRecord::Schema.define(version: 20160216172132) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -53,6 +53,7 @@ ActiveRecord::Schema.define(version: 20160212104941) do
     t.boolean  "travel_funded",        default: false, null: false
     t.text     "logo"
     t.text     "applicant_directions"
+    t.text     "rendered_description"
   end
 
   create_table "users", force: :cascade do |t|


### PR DESCRIPTION
Issue #161 

Works, but maybe there is a better gem for this. Let me know.

![bildschirmfoto 2016-02-16 um 23 57 58](https://cloud.githubusercontent.com/assets/11691539/13094259/dc7e2212-d509-11e5-817d-ac78b68b49a6.png)

![bildschirmfoto 2016-02-16 um 23 57 33](https://cloud.githubusercontent.com/assets/11691539/13094265/e2491df0-d509-11e5-8fe3-646ac7a35799.png)

