### PR TITLE
External application

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -21,6 +21,7 @@ $red: #EA5755;
 $blue: #27AAE1;
 $green: #65BE66;
 $yellow: #F8BA3F;
+$orange: #F0AD4E;
 $black: #4C5052;
 
 $small: 600px;
@@ -243,6 +244,14 @@ a {
   &:hover,
   &:active {
     background-color: darken($green, 15);
+  }
+}
+
+.btn-external {
+  background-color: $orange;
+  &:hover,
+  &:active {
+    background-color: darken($orange, 15);
   }
 }
 

--- a/app/assets/stylesheets/form.scss
+++ b/app/assets/stylesheets/form.scss
@@ -122,3 +122,7 @@ textarea {
   border: 1px solid $border-grey;
   border-radius: 2px;
 }
+
+.indent {
+  margin-left: 20px;
+}

--- a/app/assets/stylesheets/form.scss
+++ b/app/assets/stylesheets/form.scss
@@ -126,3 +126,11 @@ textarea {
 .indent {
   margin-left: 20px;
 }
+
+input.has-dependent + div.form_field {
+  display: none;
+}
+
+input.has-dependent:checked + div.form_field {
+  display: block;
+}

--- a/app/controllers/admin_events_controller.rb
+++ b/app/controllers/admin_events_controller.rb
@@ -47,7 +47,7 @@ class AdminEventsController < ApplicationController
         :description, :name, :logo, :start_date, :end_date, :approved, :ticket_funded,
         :accommodation_funded, :travel_funded, :deadline, :number_of_tickets,
         :website, :code_of_conduct, :city, :country, :applicant_directions,
-        :selection_by_organizer)
+        :application_link, :application_process)
     end
 
     def get_event

--- a/app/controllers/applications_controller.rb
+++ b/app/controllers/applications_controller.rb
@@ -7,7 +7,7 @@ class ApplicationsController < ApplicationController
   end
 
 	def new
-    if @event.manage_applications == "listing"
+    if @event.application_by_organizer?
       redirect_to @event
     else
       @application = @event.applications.build
@@ -15,7 +15,7 @@ class ApplicationsController < ApplicationController
 	end
 
   def create
-    if @event.manage_applications == "listing"
+    if @event.application_by_organizer?
       redirect_to @event
     else
       @application = Application.new(application_params)

--- a/app/controllers/applications_controller.rb
+++ b/app/controllers/applications_controller.rb
@@ -7,7 +7,7 @@ class ApplicationsController < ApplicationController
   end
 
 	def new
-    if @event.application_by_organizer?
+    if @event.application_process == 'application_by_organizer'
       redirect_to @event
     else
       @application = @event.applications.build
@@ -15,7 +15,7 @@ class ApplicationsController < ApplicationController
 	end
 
   def create
-    if @event.application_by_organizer?
+    if @event.application_process == 'application_by_organizer'
       redirect_to @event
     else
       @application = Application.new(application_params)

--- a/app/controllers/applications_controller.rb
+++ b/app/controllers/applications_controller.rb
@@ -7,17 +7,25 @@ class ApplicationsController < ApplicationController
   end
 
 	def new
-    @application = @event.applications.build
+    if @event.manage_applications == "listing"
+      redirect_to @event
+    else
+      @application = @event.applications.build
+    end
 	end
 
   def create
-    @application = Application.new(application_params)
-    @application.event = @event
-    if @application.save
-      ApplicantMailer.application_received(@application).deliver_later
-      redirect_to @event, notice: "You have successfully applied for #{@event.name}."
+    if @event.manage_applications == "listing"
+      redirect_to @event
     else
-      render :new
+      @application = Application.new(application_params)
+      @application.event = @event
+      if @application.save
+        ApplicantMailer.application_received(@application).deliver_later
+        redirect_to @event, notice: "You have successfully applied for #{@event.name}."
+      else
+        render :new
+      end
     end
   end
 

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -51,7 +51,7 @@ class EventsController < ApplicationController
         :accommodation_funded, :travel_funded, :deadline, :number_of_tickets,
         :website, :code_of_conduct, :city, :country, :applicant_directions,
         :selection_by_organizer, :data_protection_confirmation,
-        :application_link, :manage_applications)
+        :application_link, :application_by_organizer)
     end
 
     def set_s3_direct_post

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -20,7 +20,7 @@ class EventsController < ApplicationController
   end
 
   def preview
-    @event = Event.new(event_params)
+    @event = Event.new(ApplicationProcess::Params.clean(event_params))
 
     if @event.valid?
       render :preview
@@ -30,7 +30,7 @@ class EventsController < ApplicationController
   end
 
   def create
-    @event = Event.new(event_params)
+    @event = Event.new(ApplicationProcess::Params.clean(event_params))
 
     if @event.save
       User.admin.each do |user|

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -50,7 +50,7 @@ class EventsController < ApplicationController
         :description, :name, :logo, :start_date, :end_date, :approved, :ticket_funded,
         :accommodation_funded, :travel_funded, :deadline, :number_of_tickets,
         :website, :code_of_conduct, :city, :country, :applicant_directions,
-        :selection_by_organizer, :data_protection_confirmation)
+        :selection_by_organizer, :data_protection_confirmation, :application_link)
     end
 
     def set_s3_direct_post

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -50,7 +50,8 @@ class EventsController < ApplicationController
         :description, :name, :logo, :start_date, :end_date, :approved, :ticket_funded,
         :accommodation_funded, :travel_funded, :deadline, :number_of_tickets,
         :website, :code_of_conduct, :city, :country, :applicant_directions,
-        :selection_by_organizer, :data_protection_confirmation, :application_link)
+        :selection_by_organizer, :data_protection_confirmation,
+        :application_link, :manage_applications)
     end
 
     def set_s3_direct_post

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -50,8 +50,7 @@ class EventsController < ApplicationController
         :description, :name, :logo, :start_date, :end_date, :approved, :ticket_funded,
         :accommodation_funded, :travel_funded, :deadline, :number_of_tickets,
         :website, :code_of_conduct, :city, :country, :applicant_directions,
-        :selection_by_organizer, :data_protection_confirmation,
-        :application_link, :application_by_organizer)
+        :data_protection_confirmation, :application_link, :application_process)
     end
 
     def set_s3_direct_post

--- a/app/models/application_process.rb
+++ b/app/models/application_process.rb
@@ -11,8 +11,49 @@ module ApplicationProcess
     def valid?
       ALLOWED.include?(value)
     end
+
+    def selection_by_travis?
+      value == 'selection_by_travis'
+    end
+
+    def selection_by_organizer?
+      value == 'selection_by_organizer'
+    end
+
+    def application_by_organizer?
+      value == 'application_by_organizer'
+    end
   end
 
   module Validator
+    def self.included(base)
+      base.validates_each :application_process do |record, attr, value|
+        unless Choice.new(value).valid?
+          record.errors.add(attr, 'must be a valid application process')
+        end
+      end
+
+      base.validates_acceptance_of(:data_protection_confirmation, {
+        allow_nil: false,
+        if: ->(event) { Choice.new(event.application_process).selection_by_organizer? }
+      })
+
+      base.validates :application_link, {
+        if: ->(event) {
+          choice = Choice.new(event.application_process)
+          choice.application_by_organizer?
+        },
+        presence: true,
+        format: { with: /(http|https):\/\/.+\..+/ }
+      }
+
+      base.validates :application_link, {
+        if: ->(event) {
+          choice = Choice.new(event.application_process)
+          !choice.application_by_organizer?
+        },
+        absence: true
+      }
+    end
   end
 end

--- a/app/models/application_process.rb
+++ b/app/models/application_process.rb
@@ -1,0 +1,18 @@
+module ApplicationProcess
+	class Choice
+		ALLOWED = %w{ selection_by_travis selection_by_organizer application_by_organizer }
+
+		attr_reader :value
+
+		def initialize(value)
+			@value = value
+		end
+
+		def valid?
+			ALLOWED.include?(value)
+		end
+	end
+
+	module Validator
+	end
+end

--- a/app/models/application_process.rb
+++ b/app/models/application_process.rb
@@ -1,18 +1,18 @@
 module ApplicationProcess
-	class Choice
-		ALLOWED = %w{ selection_by_travis selection_by_organizer application_by_organizer }
+  class Choice
+    ALLOWED = %w{ selection_by_travis selection_by_organizer application_by_organizer }
 
-		attr_reader :value
+    attr_reader :value
 
-		def initialize(value)
-			@value = value
-		end
+    def initialize(value)
+      @value = value
+    end
 
-		def valid?
-			ALLOWED.include?(value)
-		end
-	end
+    def valid?
+      ALLOWED.include?(value)
+    end
+  end
 
-	module Validator
-	end
+  module Validator
+  end
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -12,7 +12,11 @@ class Event < ActiveRecord::Base
     allow_nil: false,
     if: ->(event) { !event.persisted? && event.selection_by_organizer? }
   })
-  validates :application_link, format: { with: /(http|https):\/\/.+\..+/ }, allow_blank: true
+  validates :application_link, {
+    if: ->(event) { !event.persisted? && event.application_by_organizer? },
+    presence: true,
+    format: { with: /(http|https):\/\/.+\..+/ }
+  }
 
   def self.approved
     where(approved: true)

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -12,7 +12,8 @@ class Event < ActiveRecord::Base
     allow_nil: false,
     if: ->(event) { !event.persisted? && event.selection_by_organizer? }
   })
-  
+  validates :application_link, format: { with: /(http|https):\/\/.+\..+/ }, allow_blank: true
+
   def self.approved
     where(approved: true)
   end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -10,10 +10,10 @@ class Event < ActiveRecord::Base
   validates :number_of_tickets, numericality: { only_integer: true, greater_than_or_equal_to: 1 }, presence: true
   validates_acceptance_of(:data_protection_confirmation, {
     allow_nil: false,
-    if: ->(event) { !event.persisted? && event.selection_by_organizer? }
+    if: ->(event) { !event.persisted? && event.application_process == 'selection_by_organizer' }
   })
   validates :application_link, {
-    if: ->(event) { !event.persisted? && event.application_by_organizer? },
+    if: ->(event) { !event.persisted? && event.application_process == 'application_by_organizer' },
     presence: true,
     format: { with: /(http|https):\/\/.+\..+/ }
   }

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -8,6 +8,9 @@ class Event < ActiveRecord::Base
   validates :organizer_email_confirmation, presence: true, on: :create
   validates :website, :code_of_conduct, format: { with: /(http|https):\/\/.+\..+/ }
   validates :number_of_tickets, numericality: { only_integer: true, greater_than_or_equal_to: 1 }, presence: true
+  validates_each :application_process do |record, attr, value|
+    record.errors.add(attr, 'must be a valid application process') unless ApplicationProcess::Choice.new(value).valid?
+  end
   validates_acceptance_of(:data_protection_confirmation, {
     allow_nil: false,
     if: ->(event) { !event.persisted? && event.application_process == 'selection_by_organizer' }

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,4 +1,5 @@
 class Event < ActiveRecord::Base
+  include ApplicationProcess::Validator
   has_many :applications, dependent: :destroy
 
   validates :organizer_name, :description, :name, :website, :code_of_conduct, :city, :country, presence: true
@@ -8,19 +9,7 @@ class Event < ActiveRecord::Base
   validates :organizer_email_confirmation, presence: true, on: :create
   validates :website, :code_of_conduct, format: { with: /(http|https):\/\/.+\..+/ }
   validates :number_of_tickets, numericality: { only_integer: true, greater_than_or_equal_to: 1 }, presence: true
-  validates_each :application_process do |record, attr, value|
-    record.errors.add(attr, 'must be a valid application process') unless ApplicationProcess::Choice.new(value).valid?
-  end
-  validates_acceptance_of(:data_protection_confirmation, {
-    allow_nil: false,
-    if: ->(event) { !event.persisted? && event.application_process == 'selection_by_organizer' }
-  })
-  validates :application_link, {
-    if: ->(event) { !event.persisted? && event.application_process == 'application_by_organizer' },
-    presence: true,
-    format: { with: /(http|https):\/\/.+\..+/ }
-  }
-
+  
   def self.approved
     where(approved: true)
   end

--- a/app/views/events/_event.html.erb
+++ b/app/views/events/_event.html.erb
@@ -43,20 +43,6 @@
 </div>
 </section>
 
-<% unless controller_name == 'events' && action_name == 'show' %>
-  <section class="box">
-    <h2 class="box-title">Selection Process Details</h2>
-    <div class="detail-pair">
-      <strong>Event organizers ask Travis Foundation to handle the applicant selection process:</strong>
-      <% if @event.selection_by_organizer? %>
-        No
-      <% else %>
-        Yes
-      <% end %>
-    </div>
-  </section>
-<% end %>
-
 <section class="box">
   <h2 class="box-title">Application Details</h2>
 
@@ -86,3 +72,21 @@
     </div>
   </div>
 </section>
+
+<% unless controller_name == 'events' && action_name == 'show' %>
+  <section class="box">
+    <h2 class="box-title box-noborder">Application and Selection</h2>
+    <p class="border">Not shown to the public.<p>
+    <div>
+      <% if @event.selection_by_organizer == false && @event.application_by_organizer == false %>
+        Both, the application and selection process shall be handled by diversitytickets.org*.
+        <p>* diversitytickets.org is an app of Travis Foundation, built by Rubymonstas. The employees of Travis Foundation will manage the application and selection processes.</p>
+      <% elsif @event.selection_by_organizer? && @event.application_by_organizer == false  %>
+        We are handling the selection process ourselves, but the application process will be handled by diversitytickets.org. We will not share the privacy, details, and answers of any applicant with third parties, including those who sponsor the diversity tickets.
+      <% elsif @event.application_by_organizer? %>
+        We are handling both the selection and application process and only want our event listed on this site. Applicants have to apply through our site / app:
+        <%= link_to @event.application_link, "#{@event.application_link}" %>
+      <% end %>
+    </div>
+  </section>
+<% end %>

--- a/app/views/events/_event.html.erb
+++ b/app/views/events/_event.html.erb
@@ -78,12 +78,12 @@
     <h2 class="box-title box-noborder">Application and Selection</h2>
     <p class="border">Not shown to the public.<p>
     <div>
-      <% if @event.selection_by_organizer == false && @event.application_by_organizer == false %>
+      <% if @event.application_process == 'selection_by_travis' %>
         Both, the application and selection process shall be handled by diversitytickets.org*.
         <p>* diversitytickets.org is an app of Travis Foundation, built by Rubymonstas. The employees of Travis Foundation will manage the application and selection processes.</p>
-      <% elsif @event.selection_by_organizer? && @event.application_by_organizer == false  %>
+      <% elsif @event.application_process == 'selection_by_organizer'  %>
         We are handling the selection process ourselves, but the application process will be handled by diversitytickets.org. We will not share the privacy, details, and answers of any applicant with third parties, including those who sponsor the diversity tickets.
-      <% elsif @event.application_by_organizer? %>
+      <% elsif @event.application_process == 'application_by_organizer' %>
         We are handling both the selection and application process and only want our event listed on this site. Applicants have to apply through our site / app:
         <%= link_to @event.application_link, "#{@event.application_link}" %>
       <% end %>

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -72,6 +72,12 @@
     <% end %>
   </div>
 
+  <h3 class="box-subtitle">Manage Application</h3>
+  <p>You can manage the diversity applications for your event by yourself or let Travis Foundation do the work for you. If you wish to manage the applications by yourself, fill in a link below, where applicants will find your application form. If you wish Travis Foundation to mangage the applications for your event, leave this blank.</p>
+  <div class="form_field">
+    <%= f.form_field :text_field, :application_link, 'Link to application form', placeholder: "e.g. https://myconference.com/apply" %>
+  </div>
+
   <% if action_name == 'edit' %>
     <h3 class="box-subtitle">Approve Event?</h3>
     <div class="form_field">

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -56,7 +56,7 @@
   <h2 class="box-title">Application & Selection</h2>
   <div class="form_field">
     <%= label_tag do %>
-      <%= f.radio_button(:application_process, 'selection_by_travis') %> Both, the application and selection process shall be handled by diversitytickets.org*.
+      <%= f.radio_button(:application_process, 'selection_by_travis', checked: 'checked') %> Both, the application and selection process shall be handled by diversitytickets.org*.
     <% end %>
 
     <%= label_tag do %>

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -56,11 +56,11 @@
   <h2 class="box-title">Application & Selection</h2>
   <div class="form_field">
     <%= label_tag do %>
-      <%= f.radio_button(:selection_by_organizer, false) %> Both, the application and selection process shall be handled by diversitytickets.org*.
+      <%= f.radio_button(:application_process, 'selection_by_travis') %> Both, the application and selection process shall be handled by diversitytickets.org*.
     <% end %>
 
     <%= label_tag do %>
-      <%= f.radio_button(:selection_by_organizer, true) %> We are handling the selection process ourselves, but the application process will be handled by diversitytickets.org.
+      <%= f.radio_button(:application_process, 'selection_by_organizer') %> We are handling the selection process ourselves, but the application process will be handled by diversitytickets.org.
 
       <div class="form_field--check indent">
         <%= label_tag do %>
@@ -75,7 +75,7 @@
     <% end %>
 
     <%= label_tag do %>
-      <%= f.radio_button(:application_by_organizer, true) %> We are handling both the selection and application process and only want our event listed on this site. Applicants have to apply through our site / app.
+      <%= f.radio_button(:application_process, 'application_by_organizer') %> We are handling both the selection and application process and only want our event listed on this site. Applicants have to apply through our site / app.
 
       <div class="form_field indent">
         <p><%= f.form_field :text_field, :application_link, 'Link to application form', placeholder: "e.g. https://myconference.com/apply" %></p>

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -71,11 +71,26 @@
       <%= f.check_box(:travel_funded) %> Travel
     <% end %>
   </div>
+</section>
 
-  <h3 class="box-subtitle">Manage Application</h3>
-  <p>You can manage the diversity applications for your event by yourself or let Travis Foundation do the work for you. If you wish to manage the applications by yourself, fill in a link below, where applicants will find your application form. If you wish Travis Foundation to mangage the applications for your event, leave this blank.</p>
+<section class="box">
+  <h2 class="box-title">Manage Diversity Tickets</h2>
+  <p>There are 3 possibilities how you can use diversitytickets.org:<p>
   <div class="form_field">
-    <%= f.form_field :text_field, :application_link, 'Link to application form', placeholder: "e.g. https://myconference.com/apply" %>
+    <%= label_tag do %>
+      <%= f.radio_button(:manage_applications, "listing") %> You can advertise your events diversity tickets here and add a link to your application form.
+
+      <div class="form_field">
+        <p><%= f.form_field :text_field, :application_link, 'Link to application form', placeholder: "e.g. https://myconference.com/apply" %></p>
+      </div>
+
+    <% end %>
+    <%= label_tag do %>
+      <%= f.radio_button(:manage_applications, "applications") %> Applicants can apply for your diversity tickets here, but you will do the selection by yourself.
+    <% end %>
+    <%= label_tag do %>
+      <%= f.radio_button(:manage_applications, "selection") %> You let Travis Foundation do the selection for you.
+    <% end %>
   </div>
 
   <% if action_name == 'edit' %>

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -60,7 +60,7 @@
     <% end %>
 
     <%= label_tag do %>
-      <%= f.radio_button(:application_process, 'selection_by_organizer') %> We are handling the selection process ourselves, but the application process will be handled by diversitytickets.org.
+      <%= f.radio_button(:application_process, 'selection_by_organizer', class: 'has-dependent') %> We are handling the selection process ourselves, but the application process will be handled by diversitytickets.org.
 
       <div class="form_field--check indent">
         <%= label_tag do %>
@@ -75,7 +75,7 @@
     <% end %>
 
     <%= label_tag do %>
-      <%= f.radio_button(:application_process, 'application_by_organizer') %> We are handling both the selection and application process and only want our event listed on this site. Applicants have to apply through our site / app.
+      <%= f.radio_button(:application_process, 'application_by_organizer', class: 'has-dependent') %> We are handling both the selection and application process and only want our event listed on this site. Applicants have to apply through our site / app.
 
       <div class="form_field indent">
         <p><%= f.form_field :text_field, :application_link, 'Link to application form', placeholder: "e.g. https://myconference.com/apply" %></p>

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -33,27 +33,6 @@
 </section>
 
 <section class="box">
-  <h2 class="box-title">Selection Process</h2>
-  <div class="form_field">
-    <%= label_tag do %>
-      <%= f.radio_button(:selection_by_organizer, false) %> We ask Travis Foundation to handle the applicant selection process for our event's diversity tickets.
-    <% end %>
-    <%= label_tag do %>
-      <%= f.radio_button(:selection_by_organizer, true) %> We will handle the applicant selection process for our event's diversity tickets ourselves.
-    <% end %>
-  </div>
-  <div class="form_field--check">
-    <%= label_tag do %>
-      <%= f.check_box :data_protection_confirmation %>
-      <span class="check-label">If we choose to handle the applicant selection process ourselves, we agree with the following Terms and Conditions:</span>
-    <% end %>
-    <p id="terms-and-conditions">
-      We will not share the privacy, details, and answers of any applicant with third parties, including those who sponsor the diversity tickets.
-    </p>
-  </div>
-</section>
-
-<section class="box">
   <h2 class="box-title">Application Details</h2>
   <%= f.form_field :text_area, :applicant_directions, 'Directions for Applicants', class: ['markdown'] %>
   <%= f.form_field :date_field, :deadline, 'Deadline for Application', class: ['right'], placeholder: "dd.mm.yyyy" %>
@@ -74,26 +53,42 @@
 </section>
 
 <section class="box">
-  <h2 class="box-title">Manage Diversity Tickets</h2>
-  <p>There are 3 possibilities how you can use diversitytickets.org:<p>
+  <h2 class="box-title">Application & Selection</h2>
   <div class="form_field">
     <%= label_tag do %>
-      <%= f.radio_button(:manage_applications, "listing") %> You can advertise your events diversity tickets here and add a link to your application form.
+      <%= f.radio_button(:selection_by_organizer, false) %> Both, the application and selection process shall be handled by diversitytickets.org*.
+    <% end %>
 
-      <div class="form_field">
+    <%= label_tag do %>
+      <%= f.radio_button(:selection_by_organizer, true) %> We are handling the selection process ourselves, but the application process will be handled by diversitytickets.org.
+
+      <div class="form_field--check indent">
+        <%= label_tag do %>
+          <%= f.check_box :data_protection_confirmation %>
+          <span class="check-label">We agree with the following Terms and Conditions:</span>
+        <% end %>
+        <p id="terms-and-conditions">
+          We will not share the privacy, details, and answers of any applicant with third parties, including those who sponsor the diversity tickets.
+        </p>
+      </div>
+
+    <% end %>
+
+    <%= label_tag do %>
+      <%= f.radio_button(:application_by_organizer, true) %> We are handling both the selection and application process and only want our event listed on this site. Applicants have to apply through our site / app.
+
+      <div class="form_field indent">
         <p><%= f.form_field :text_field, :application_link, 'Link to application form', placeholder: "e.g. https://myconference.com/apply" %></p>
       </div>
 
     <% end %>
-    <%= label_tag do %>
-      <%= f.radio_button(:manage_applications, "applications") %> Applicants can apply for your diversity tickets here, but you will do the selection by yourself.
-    <% end %>
-    <%= label_tag do %>
-      <%= f.radio_button(:manage_applications, "selection") %> You let Travis Foundation do the selection for you.
-    <% end %>
   </div>
 
-  <% if action_name == 'edit' %>
+  <p>* diversitytickets.org is an app of Travis Foundation, built by Rubymonstas. The employees of Travis Foundation will manage the application and selection processes.</p>
+</section>
+
+<% if action_name == 'edit' %>
+  <section class="box">
     <h3 class="box-subtitle">Approve Event?</h3>
     <div class="form_field">
       <%= label_tag do %>
@@ -105,7 +100,8 @@
     </div>
   <% end %>
 </section>
+
 <div class="form_field">
-      <%= f.submit(submit_tag_text, class: 'btn btn-save') %>
-  </div>
+  <%= f.submit(submit_tag_text, class: 'btn btn-save') %>
+</div>
 <% end %>

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -13,7 +13,7 @@
       <h3><%= link_to event.name, event_path(:id => event.id) %></h3>
       <p class="markdownize"><%= event.description %></p>
       <% if event.open? %>
-        <% if event.application_by_organizer? %>
+        <% if event.application_process == 'application_by_organizer' %>
           <%= link_to "Apply at #{event.name}", event.application_link, class:'btn btn-save btn-external' %>
         <% else %>
           <%= link_to 'Apply', new_event_application_path(:event_id => event.id), class:'btn btn-save' %>

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -13,7 +13,7 @@
       <h3><%= link_to event.name, event_path(:id => event.id) %></h3>
       <p class="markdownize"><%= event.description %></p>
       <% if event.open? %>
-        <% if event.manage_applications == "listing" %>
+        <% if event.application_by_organizer? %>
           <%= link_to "Apply at #{event.name}", event.application_link, class:'btn btn-save btn-external' %>
         <% else %>
           <%= link_to 'Apply', new_event_application_path(:event_id => event.id), class:'btn btn-save' %>
@@ -24,4 +24,4 @@
 
 <% end %>
 
-  <%= link_to 'Show past events', past_events_path if @past_events.any? %>
+<%= link_to 'Show past events', past_events_path if @past_events.any? %>

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -22,6 +22,5 @@
     </div>
   <% end %>
 
+  <%= link_to 'Show past events', past_events_path if @past_events.any? %>
 <% end %>
-
-<%= link_to 'Show past events', past_events_path if @past_events.any? %>

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -7,15 +7,21 @@
 </div>
 
 <% else %>
+
   <% @events.each do |event| %>
     <div class="box event">
       <h3><%= link_to event.name, event_path(:id => event.id) %></h3>
       <p class="markdownize"><%= event.description %></p>
       <% if event.open? %>
-        <%= link_to 'Apply', new_event_application_path(:event_id => event.id), class:'btn btn-save' %>
+        <% if event.manage_applications == "listing" %>
+          <%= link_to "Apply at #{event.name}", event.application_link, class:'btn btn-save btn-external' %>
+        <% else %>
+          <%= link_to 'Apply', new_event_application_path(:event_id => event.id), class:'btn btn-save' %>
+        <% end %>
       <% end %>
     </div>
   <% end %>
 
-  <%= link_to 'Show past events', past_events_path if @past_events.any? %>
 <% end %>
+
+  <%= link_to 'Show past events', past_events_path if @past_events.any? %>

--- a/app/views/events/preview.html.erb
+++ b/app/views/events/preview.html.erb
@@ -15,6 +15,20 @@
 
 <%= render :partial => "events/event" %>
 
+<section class="box">
+  <h2 class="box-title box-noborder">Manage Applications</h2>
+  <p class="border">Not shown to the public.<p>
+  <div>
+    <% if @event.manage_applications == "listing" %>
+      I only want to advertise my events diversity tickets on diversitytickets.org, please send applicants to this link to apply: <%= link_to @event.application_link, "#{@event.application_link}" %>
+    <% elsif @event.manage_applications == "applications" %>
+      Applicants apply via diversitytickets.org, I will do the selection by myself.
+    <% elsif @event.manage_applications == "selection" %>
+      Applicants apply via diversitytickets.org, Travis Foundation will to do the selection for the diversity tickets winners.
+    <% end %>
+  </div>
+</section>
+
 <%= form_for @event, url: events_path do |f| %>
   <%= f.hidden_field :name %>
   <%= f.hidden_field :logo %>
@@ -34,9 +48,11 @@
   <%= f.hidden_field :ticket_funded %>
   <%= f.hidden_field :accommodation_funded %>
   <%= f.hidden_field :travel_funded %>
+  <%= f.hidden_field :application_link %>
+  <%= f.hidden_field :manage_applications %>
+
   <div class="form_field">
     <a class="btn btn-edit" href="javascript:history.back()">Edit event</a>
     <%= f.submit "Save your event", :class => "btn btn-save" %>
   </div>
 <% end %>
-

--- a/app/views/events/preview.html.erb
+++ b/app/views/events/preview.html.erb
@@ -35,8 +35,7 @@
   <%= f.hidden_field :accommodation_funded %>
   <%= f.hidden_field :travel_funded %>
   <%= f.hidden_field :application_link %>
-  <%= f.hidden_field :selection_by_organizer %>
-  <%= f.hidden_field :application_by_organizer %>
+  <%= f.hidden_field :application_process %>
   <%= f.hidden_field :data_protection_confirmation %>
 
   <div class="form_field">

--- a/app/views/events/preview.html.erb
+++ b/app/views/events/preview.html.erb
@@ -15,20 +15,6 @@
 
 <%= render :partial => "events/event" %>
 
-<section class="box">
-  <h2 class="box-title box-noborder">Manage Applications</h2>
-  <p class="border">Not shown to the public.<p>
-  <div>
-    <% if @event.manage_applications == "listing" %>
-      I only want to advertise my events diversity tickets on diversitytickets.org, please send applicants to this link to apply: <%= link_to @event.application_link, "#{@event.application_link}" %>
-    <% elsif @event.manage_applications == "applications" %>
-      Applicants apply via diversitytickets.org, I will do the selection by myself.
-    <% elsif @event.manage_applications == "selection" %>
-      Applicants apply via diversitytickets.org, Travis Foundation will to do the selection for the diversity tickets winners.
-    <% end %>
-  </div>
-</section>
-
 <%= form_for @event, url: events_path do |f| %>
   <%= f.hidden_field :name %>
   <%= f.hidden_field :logo %>
@@ -49,7 +35,9 @@
   <%= f.hidden_field :accommodation_funded %>
   <%= f.hidden_field :travel_funded %>
   <%= f.hidden_field :application_link %>
-  <%= f.hidden_field :manage_applications %>
+  <%= f.hidden_field :selection_by_organizer %>
+  <%= f.hidden_field :application_by_organizer %>
+  <%= f.hidden_field :data_protection_confirmation %>
 
   <div class="form_field">
     <a class="btn btn-edit" href="javascript:history.back()">Edit event</a>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -5,7 +5,11 @@
 <%= render :partial => "events/event" %>
 
 <% if @event.open? %>
-  <%= link_to 'Apply', new_event_application_path(params[:id]), class:'btn btn-save' %><br>
+  <% if @event.application_link.present? %>
+    <%= link_to 'Apply', @event.application_link, class:'btn btn-save' %><br>
+  <% else %>
+    <%= link_to 'Apply', new_event_application_path(params[:id]), class:'btn btn-save' %><br>
+  <% end %>
 <% else %>
   <strong>Sorry, application for <%= @event.name %> is closed.</strong>
 <% end %>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -5,8 +5,8 @@
 <%= render :partial => "events/event" %>
 
 <% if @event.open? %>
-  <% if @event.application_link.present? %>
-    <%= link_to 'Apply', @event.application_link, class:'btn btn-save' %><br>
+  <% if @event.manage_applications == "listing" %>
+    <%= link_to "Apply at #{@event.name}", @event.application_link, class:'btn btn-save btn-external' %><br>
   <% else %>
     <%= link_to 'Apply', new_event_application_path(params[:id]), class:'btn btn-save' %><br>
   <% end %>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -5,7 +5,7 @@
 <%= render :partial => "events/event" %>
 
 <% if @event.open? %>
-  <% if @event.manage_applications == "listing" %>
+  <% if @event.application_by_organizer? %>
     <%= link_to "Apply at #{@event.name}", @event.application_link, class:'btn btn-save btn-external' %><br>
   <% else %>
     <%= link_to 'Apply', new_event_application_path(params[:id]), class:'btn btn-save' %><br>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -5,7 +5,7 @@
 <%= render :partial => "events/event" %>
 
 <% if @event.open? %>
-  <% if @event.application_by_organizer? %>
+  <% if @event.application_process == 'application_by_organizer' %>
     <%= link_to "Apply at #{@event.name}", @event.application_link, class:'btn btn-save btn-external' %><br>
   <% else %>
     <%= link_to 'Apply', new_event_application_path(params[:id]), class:'btn btn-save' %><br>

--- a/db/migrate/20160412103125_add_application_link_to_events.rb
+++ b/db/migrate/20160412103125_add_application_link_to_events.rb
@@ -1,0 +1,5 @@
+class AddApplicationLinkToEvents < ActiveRecord::Migration
+  def change
+    add_column :events, :application_link, :text
+  end
+end

--- a/db/migrate/20160511140500_add_manage_applications_options_to_events.rb
+++ b/db/migrate/20160511140500_add_manage_applications_options_to_events.rb
@@ -1,5 +1,0 @@
-class AddManageApplicationsOptionsToEvents < ActiveRecord::Migration
-  def change
-    add_column :events, :manage_applications, :string
-  end
-end

--- a/db/migrate/20160511140500_add_manage_applications_options_to_events.rb
+++ b/db/migrate/20160511140500_add_manage_applications_options_to_events.rb
@@ -1,0 +1,5 @@
+class AddManageApplicationsOptionsToEvents < ActiveRecord::Migration
+  def change
+    add_column :events, :manage_applications, :string
+  end
+end

--- a/db/migrate/20160612105514_add_application_process_to_events.rb
+++ b/db/migrate/20160612105514_add_application_process_to_events.rb
@@ -1,0 +1,5 @@
+class AddApplicationProcessToEvents < ActiveRecord::Migration
+  def change
+    add_column :events, :application_by_organizer, :boolean, default: false, null: false
+  end
+end

--- a/db/migrate/20160612105514_add_application_process_to_events.rb
+++ b/db/migrate/20160612105514_add_application_process_to_events.rb
@@ -1,5 +1,5 @@
 class AddApplicationProcessToEvents < ActiveRecord::Migration
   def change
-    add_column :events, :application_by_organizer, :boolean, default: false, null: false
+    add_column :events, :application_process, :string
   end
 end

--- a/db/migrate/20160722160616_remove_selection_by_organizer_from_events.rb
+++ b/db/migrate/20160722160616_remove_selection_by_organizer_from_events.rb
@@ -1,0 +1,5 @@
+class RemoveSelectionByOrganizerFromEvents < ActiveRecord::Migration
+  def change
+    remove_column :events, :selection_by_organizer, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -38,28 +38,24 @@ ActiveRecord::Schema.define(version: 20160612105514) do
     t.text     "description"
     t.text     "name"
     t.date     "start_date"
-    t.datetime "created_at",                               null: false
-    t.datetime "updated_at",                               null: false
+    t.datetime "created_at",                             null: false
+    t.datetime "updated_at",                             null: false
     t.date     "end_date"
-    t.boolean  "approved",                 default: false, null: false
+    t.boolean  "approved",               default: false, null: false
     t.text     "website"
     t.text     "code_of_conduct"
     t.string   "city"
     t.string   "country"
     t.date     "deadline"
     t.integer  "number_of_tickets"
-    t.boolean  "ticket_funded",            default: false, null: false
-    t.boolean  "accommodation_funded",     default: false, null: false
-    t.boolean  "travel_funded",            default: false, null: false
+    t.boolean  "ticket_funded",          default: false, null: false
+    t.boolean  "accommodation_funded",   default: false, null: false
+    t.boolean  "travel_funded",          default: false, null: false
     t.text     "logo"
     t.text     "applicant_directions"
-    t.text     "rendered_description"
-    t.text     "application_link"
-    t.boolean  "application_by_organizer", default: false, null: false
-    t.integer  "organizer_id"
     t.boolean  "selection_by_organizer", default: false, null: false
-    t.text     "applicant_directions"
-    t.boolean  "application_by_organizer", default: false, null: false
+    t.text     "application_link"
+    t.string   "application_process"
   end
 
   create_table "users", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -58,8 +58,8 @@ ActiveRecord::Schema.define(version: 20160612105514) do
     t.boolean  "application_by_organizer", default: false, null: false
     t.integer  "organizer_id"
     t.boolean  "selection_by_organizer", default: false, null: false
-    t.text     "application_link"
-    t.string   "manage_applications"
+    t.text     "applicant_directions"
+    t.boolean  "application_by_organizer", default: false, null: false
   end
 
   create_table "users", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160612105514) do
+ActiveRecord::Schema.define(version: 20160722160616) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -19,15 +19,14 @@ ActiveRecord::Schema.define(version: 20160612105514) do
   create_table "applications", force: :cascade do |t|
     t.string   "name"
     t.string   "email"
-    t.datetime "created_at",                           null: false
-    t.datetime "updated_at",                           null: false
+    t.datetime "created_at",                      null: false
+    t.datetime "updated_at",                      null: false
     t.integer  "event_id"
     t.text     "attendee_info_1"
     t.text     "attendee_info_2"
-    t.boolean  "ticket_needed",        default: false, null: false
-    t.boolean  "travel_needed",        default: false, null: false
-    t.boolean  "accommodation_needed", default: false, null: false
-    t.boolean  "visa_needed",          default: false, null: false
+    t.boolean  "ticket_needed",   default: false, null: false
+    t.boolean  "travel_needed",   default: false, null: false
+    t.boolean  "visa_needed",     default: false, null: false
   end
 
   add_index "applications", ["event_id"], name: "index_applications_on_event_id", using: :btree
@@ -38,25 +37,27 @@ ActiveRecord::Schema.define(version: 20160612105514) do
     t.text     "description"
     t.text     "name"
     t.date     "start_date"
-    t.datetime "created_at",                             null: false
-    t.datetime "updated_at",                             null: false
+    t.datetime "created_at",                           null: false
+    t.datetime "updated_at",                           null: false
     t.date     "end_date"
-    t.boolean  "approved",               default: false, null: false
+    t.boolean  "approved",             default: false, null: false
     t.text     "website"
     t.text     "code_of_conduct"
     t.string   "city"
     t.string   "country"
     t.date     "deadline"
     t.integer  "number_of_tickets"
-    t.boolean  "ticket_funded",          default: false, null: false
-    t.boolean  "accommodation_funded",   default: false, null: false
-    t.boolean  "travel_funded",          default: false, null: false
-    t.text     "logo"
+    t.boolean  "ticket_funded",        default: false, null: false
+    t.boolean  "accommodation_funded", default: false, null: false
+    t.boolean  "travel_funded",        default: false, null: false
     t.text     "applicant_directions"
-    t.boolean  "selection_by_organizer", default: false, null: false
+    t.integer  "organizer_id"
+    t.text     "logo"
     t.text     "application_link"
     t.string   "application_process"
   end
+
+  add_index "events", ["organizer_id"], name: "index_events_on_organizer_id", using: :btree
 
   create_table "users", force: :cascade do |t|
     t.datetime "created_at",                                     null: false
@@ -72,4 +73,5 @@ ActiveRecord::Schema.define(version: 20160612105514) do
   add_index "users", ["remember_token"], name: "index_users_on_remember_token", using: :btree
 
   add_foreign_key "applications", "events"
+  add_foreign_key "events", "users", column: "organizer_id"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -59,6 +59,7 @@ ActiveRecord::Schema.define(version: 20160612105514) do
     t.integer  "organizer_id"
     t.boolean  "selection_by_organizer", default: false, null: false
     t.text     "application_link"
+    t.string   "manage_applications"
   end
 
   create_table "users", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -58,6 +58,7 @@ ActiveRecord::Schema.define(version: 20160612105514) do
     t.boolean  "application_by_organizer", default: false, null: false
     t.integer  "organizer_id"
     t.boolean  "selection_by_organizer", default: false, null: false
+    t.text     "application_link"
   end
 
   create_table "users", force: :cascade do |t|

--- a/test/controllers/events_controller_test.rb
+++ b/test/controllers/events_controller_test.rb
@@ -65,7 +65,7 @@ class EventsControllerTest < ActionController::TestCase
 
   test "choosing selection by organizer and not agreeing to protect data fails" do
     params = make_event_form_params(application_process: 'selection_by_organizer',
-                                    data_protection_confirmation: nil)
+                                    data_protection_confirmation: '0')
 
     post :create, event: params
 
@@ -78,6 +78,18 @@ class EventsControllerTest < ActionController::TestCase
     post :create, event: params
 
     assert_equal false, Event.last.application_process == 'selection_by_organizer'
+  end
+
+  test "irrelevant selection & application process data is thrown away" do
+    params = make_event_form_params(
+      application_process: 'selection_by_travis',
+      data_protection_confirmation: '1',
+      application_link: 'somelink.tada'
+    )
+
+    post :create, event: params
+
+    assert_equal false, Event.last.application_process == 'selection_by_organizer'   
   end
 
   test "index action has apply link for event with deadline in the future" do

--- a/test/controllers/events_controller_test.rb
+++ b/test/controllers/events_controller_test.rb
@@ -69,18 +69,18 @@ class EventsControllerTest < ActionController::TestCase
   end
 
   test "choosing selection by organizer and agreeing to protect data creates event correctly" do
-    params = make_event_form_params(  selection_by_organizer: true,
-                                      data_protection_confirmation: '1')
+    params = make_event_form_params(application_process: 'selection_by_organizer',
+                                    data_protection_confirmation: '1')
 
     post :create, event: params
 
     assert_response :redirect
-    assert Event.first.selection_by_organizer
+    assert Event.first.application_process == 'selection_by_organizer'
   end
 
   test "choosing selection by organizer and not agreeing to protect data fails" do
-    params = make_event_form_params(  selection_by_organizer: true,
-                                      data_protection_confirmation: nil)
+    params = make_event_form_params(application_process: 'selection_by_organizer',
+                                    data_protection_confirmation: nil)
 
     post :create, event: params
 
@@ -88,11 +88,11 @@ class EventsControllerTest < ActionController::TestCase
   end
 
   test "choosing selection not by organizer (instead e.g. Travis Foundation) and not agreeing to protect data still creates event correctly" do
-    params = make_event_form_params
+    params = make_event_form_params(application_process: 'selection_by_travis')
 
     post :create, event: params
 
-    assert_equal false, Event.last.selection_by_organizer
+    assert_equal false, Event.last.application_process == 'selection_by_organizer'
   end
 
   test "index action has apply link for event with deadline in the future" do

--- a/test/controllers/events_controller_test.rb
+++ b/test/controllers/events_controller_test.rb
@@ -5,31 +5,16 @@ class EventsControllerTest < ActionController::TestCase
     #create admin
     make_admin
 
-    post :create, event: {
-          name: 'Event',
-          start_date: 1.week.from_now,
-          end_date: 2.weeks.from_now,
-          description: 'Sed ut perspiciatis unde omnis.',
-          organizer_name: 'Klaus Mustermann',
-          organizer_email: 'klaus@example.com',
-          organizer_email_confirmation: 'klaus@example.com',
-          website: 'http://google.com',
-          code_of_conduct: 'http://coc.website',
-          city: 'Berlin',
-          country: 'Germany',
-          deadline: 5.days.from_now,
-          number_of_tickets: 10,
-          approved: false
-        }
+    post :create, event: make_event_form_params
 
-      assert_equal 'You have successfully created Event.', flash[:notice]
-      assert_redirected_to events_path
-      admin_email = ActionMailer::Base.deliveries.find {|d| d.to == ["admin@woo.hoo"]}
-      assert_equal admin_email.subject, "A new event has been submitted."
-      organizer_email = ActionMailer::Base.deliveries.find {|d| d.to == ["klaus@example.com"]}
-      assert_equal organizer_email.subject, "You submitted a new event."
-      assert_equal Event.last.name, 'Event'
-      assert_equal Event.last.approved, false
+    assert_equal 'You have successfully created Event.', flash[:notice]
+    assert_redirected_to events_path
+    admin_email = ActionMailer::Base.deliveries.find {|d| d.to == ["admin@woo.hoo"]}
+    assert_equal admin_email.subject, "A new event has been submitted."
+    organizer_email = ActionMailer::Base.deliveries.find {|d| d.to == ["klaus@example.com"]}
+    assert_equal organizer_email.subject, "You submitted a new event."
+    assert_equal Event.last.name, 'Event'
+    assert_equal Event.last.approved, false
   end
 
   test "index action shows only approved events" do

--- a/test/models/application_process_test.rb
+++ b/test/models/application_process_test.rb
@@ -1,18 +1,17 @@
 require 'test_helper'
 
 class ApplicationProcessTest < ActiveSupport::TestCase
+  describe 'handling application process' do
+    it 'is valid if its value is allowed' do
+      choice = ApplicationProcess::Choice.new('selection_by_organizer')
 
-	describe 'handling application process' do
-		it 'is valid if its value is allowed' do
-			choice = ApplicationProcess::Choice.new('selection_by_organizer')
+      assert_equal true, choice.valid?
+    end
 
-			assert_equal true, choice.valid?
-		end
+    it 'is not valid if its value is not allowed' do
+      choice = ApplicationProcess::Choice.new('random value')
 
-		it 'is not valid if its value is not allowed' do
-			choice = ApplicationProcess::Choice.new('random value')
-
-			assert_equal false, choice.valid?
-		end
-	end
+      assert_equal false, choice.valid?
+    end
+  end
 end

--- a/test/models/application_process_test.rb
+++ b/test/models/application_process_test.rb
@@ -1,0 +1,18 @@
+require 'test_helper'
+
+class ApplicationProcessTest < ActiveSupport::TestCase
+
+	describe 'handling application process' do
+		it 'is valid if its value is allowed' do
+			choice = ApplicationProcess::Choice.new('selection_by_organizer')
+
+			assert_equal true, choice.valid?
+		end
+
+		it 'is not valid if its value is not allowed' do
+			choice = ApplicationProcess::Choice.new('random value')
+
+			assert_equal false, choice.valid?
+		end
+	end
+end

--- a/test/models/application_process_test.rb
+++ b/test/models/application_process_test.rb
@@ -26,4 +26,42 @@ class ApplicationProcessTest < ActiveSupport::TestCase
       assert !choice.application_by_organizer?      
     end
   end
+
+  describe 'cleaning event params' do
+    it 'gets rid of data protection check and application link if selection by Travis' do
+      event_params = {
+        application_process: 'selection_by_travis',
+        data_protection_confirmation: '1',
+        application_link: 'some_link.org'
+      }
+
+      clean_event_params = ApplicationProcess::Params.clean(event_params)
+
+      assert_equal clean_event_params, {application_process: 'selection_by_travis'}
+    end
+
+    it 'gets rid of application link if selection by organizer' do
+      event_params = {
+        application_process: 'selection_by_organizer',
+        data_protection_confirmation: '1',
+        application_link: 'some_link.org'
+      }
+
+      clean_event_params = ApplicationProcess::Params.clean(event_params)
+
+      assert_equal clean_event_params, {application_process: 'selection_by_organizer', data_protection_confirmation: '1'}
+    end
+
+    it 'gets rid of data protection check if application_by_organizer' do
+      event_params = {
+        application_process: 'application_by_organizer',
+        data_protection_confirmation: '1',
+        application_link: 'some_link.org'
+      }
+
+      clean_event_params = ApplicationProcess::Params.clean(event_params)
+
+      assert_equal clean_event_params, {application_process: 'application_by_organizer', application_link: 'some_link.org'}
+    end
+  end
 end

--- a/test/models/application_process_test.rb
+++ b/test/models/application_process_test.rb
@@ -13,5 +13,17 @@ class ApplicationProcessTest < ActiveSupport::TestCase
 
       assert_equal false, choice.valid?
     end
+
+    it 'reports it is a selection by travis event' do
+      choice = ApplicationProcess::Choice.new('selection_by_travis')
+
+      assert choice.selection_by_travis?
+    end
+
+    it 'reports it is not an application by organizer event' do
+      choice = ApplicationProcess::Choice.new('selection_by_travis')
+
+      assert !choice.application_by_organizer?      
+    end
   end
 end

--- a/test/models/event_test.rb
+++ b/test/models/event_test.rb
@@ -52,4 +52,11 @@ class EventTest < ActiveSupport::TestCase
       assert_attribute_invalid(event, :website)
     end
   end
+
+  describe "validating application process" do
+    it 'should not allow invalid application process' do
+      event = Event.new(application_process: 'bad')
+      assert_attribute_invalid(event, :application_process)
+    end
+  end
 end

--- a/test/models/event_test.rb
+++ b/test/models/event_test.rb
@@ -59,6 +59,18 @@ class EventTest < ActiveSupport::TestCase
       assert_attribute_invalid(event, :application_process)
     end
 
+    describe "T&C confirmation checkbox" do
+      it 'must be checked if organizers handle selection by themselves' do
+        event = Event.new(application_process: 'selection_by_organizer', data_protection_confirmation: "0")
+        assert_attribute_invalid(event, :data_protection_confirmation)
+      end
+
+      it 'should not be checked if organizers do not handle selection by themselves' do
+        event = Event.new(application_process: 'selection_by_travis', data_protection_confirmation: "1")
+        assert_attribute_invalid(event, :data_protection_confirmation)
+      end
+    end
+
     describe "application_link" do
       it 'must be blank if application process not handled by organizer' do
         event = Event.new(application_process: 'selection_by_travis', application_link: 'https://something.org')

--- a/test/models/event_test.rb
+++ b/test/models/event_test.rb
@@ -58,5 +58,19 @@ class EventTest < ActiveSupport::TestCase
       event = Event.new(application_process: 'bad')
       assert_attribute_invalid(event, :application_process)
     end
+
+    describe "application_link" do
+      it 'must be blank if application process not handled by organizer' do
+        event = Event.new(application_process: 'selection_by_travis', application_link: 'https://something.org')
+
+        assert_attribute_invalid(event, :application_link)
+      end
+
+      it 'should contain a valid link if application is handled by organizer' do
+        event = Event.new(application_process: 'application_by_organizer')
+
+        assert_attribute_invalid(event, :application_link)
+      end
+    end
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -51,7 +51,8 @@ class ActiveSupport::TestCase
       country: 'Germany',
       deadline: 5.days.from_now,
       number_of_tickets: 10,
-      approved: false
+      approved: false,
+      application_process: 'selection_by_travis'
     }
     event_params = defaults.merge(event_params)
     Event.create!(event_params)
@@ -71,7 +72,8 @@ class ActiveSupport::TestCase
       city: 'Berlin',
       country: 'Germany',
       deadline: 5.days.from_now,
-      number_of_tickets: 10
+      number_of_tickets: 10,
+      application_process: 'selection_by_travis'
     }
     defaults.merge(event_params)
   end


### PR DESCRIPTION
Addresses Issue #168 

I added a field application_link to events.
The organizers can fill this field if they want to manage the applications themselves or they can leave this field blank if they want Travis Foundation to manage them (via this app).
The apply link will be the link to the external application form if the organizer put one in.

What do you think? If we want to use this or something like this we would get much more events to use this site (for advertising their diversity tickets). We might have to adjust some texts and other things.

@anikalindtner & @alicetragedy 