### PR TITLE
Automatically tweet event after approval

### DIFF
--- a/.env_example
+++ b/.env_example
@@ -1,0 +1,4 @@
+TWITTER_CONSUMER_KEY=thisneedstobedifferent!
+TWITTER_CONSUMER_SECRET=thisneedstobedifferent!
+TWITTER_ACCESS_TOKEN=thisneedstobedifferent!
+TWITTER_ACCESS_SECRET=thisneedstobedifferent!

--- a/Gemfile
+++ b/Gemfile
@@ -54,6 +54,8 @@ group :development, :test do
   gem 'pry'
 
   gem 'foreman'
+
+  gem 'mocha'
 end
 
 group :development do

--- a/Gemfile
+++ b/Gemfile
@@ -33,6 +33,8 @@ gem 'puma'
 
 gem 'aws-sdk', '~> 2'
 
+gem 'twitter'
+
 # Use ActiveModel has_secure_password
 # gem 'bcrypt', '~> 3.1.7'
 
@@ -50,6 +52,8 @@ group :development, :test do
   gem 'spring'
   # Pry
   gem 'pry'
+
+  gem 'foreman'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -36,6 +36,7 @@ GEM
       minitest (~> 5.1)
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
+    addressable (2.4.0)
     arel (6.0.3)
     autoprefixer-rails (6.3.6.2)
       execjs
@@ -48,6 +49,7 @@ GEM
     bcrypt (3.1.11)
     binding_of_caller (0.7.2)
       debug_inspector (>= 0.0.1)
+    buftok (0.2.0)
     builder (3.2.2)
     byebug (9.0.5)
     clearance (1.14.1)
@@ -69,16 +71,32 @@ GEM
       activesupport
     debug_inspector (0.0.2)
     docile (1.1.5)
+    domain_name (0.5.20160310)
+      unf (>= 0.0.5, < 1.0.0)
     dotenv (2.1.1)
     dotenv-rails (2.1.1)
       dotenv (= 2.1.1)
       railties (>= 4.0, < 5.1)
     email_validator (1.6.0)
       activemodel
+    equalizer (0.0.10)
     erubis (2.7.0)
     execjs (2.7.0)
+    faraday (0.9.2)
+      multipart-post (>= 1.2, < 3)
+    foreman (0.82.0)
+      thor (~> 0.19.1)
     globalid (0.3.6)
       activesupport (>= 4.1.0)
+    http (1.0.4)
+      addressable (~> 2.3)
+      http-cookie (~> 1.0)
+      http-form_data (~> 1.0.1)
+      http_parser.rb (~> 0.6.0)
+    http-cookie (1.0.2)
+      domain_name (~> 0.5)
+    http-form_data (1.0.1)
+    http_parser.rb (0.6.0)
     i18n (0.7.0)
     jbuilder (2.5.0)
       activesupport (>= 3.0.0, < 5.1)
@@ -95,6 +113,8 @@ GEM
       nokogiri (>= 1.5.9)
     mail (2.6.4)
       mime-types (>= 1.16, < 4)
+    memoizable (0.4.2)
+      thread_safe (~> 0.3, >= 0.3.1)
     method_source (0.8.2)
     mime-types (3.1)
       mime-types-data (~> 3.2015)
@@ -105,6 +125,8 @@ GEM
       minitest (~> 5.0)
       rails (>= 4.1)
     multi_json (1.12.1)
+    multipart-post (2.0.0)
+    naught (1.1.0)
     nokogiri (1.6.8)
       mini_portile2 (~> 2.1.0)
       pkg-config (~> 1.1.7)
@@ -160,6 +182,7 @@ GEM
       concurrent-ruby (~> 1.0)
       connection_pool (~> 2.2, >= 2.2.0)
       redis (~> 3.2, >= 3.2.1)
+    simple_oauth (0.3.1)
     simplecov (0.11.2)
       docile (~> 1.1.0)
       json (~> 1.8)
@@ -179,10 +202,24 @@ GEM
     tilt (2.0.5)
     turbolinks (2.5.3)
       coffee-rails
+    twitter (5.16.0)
+      addressable (~> 2.3)
+      buftok (~> 0.2.0)
+      equalizer (= 0.0.10)
+      faraday (~> 0.9.0)
+      http (~> 1.0)
+      http_parser.rb (~> 0.6.0)
+      json (~> 1.8)
+      memoizable (~> 0.4.0)
+      naught (~> 1.0)
+      simple_oauth (~> 0.3.0)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
     uglifier (3.0.0)
       execjs (>= 0.3.0, < 3)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.7.2)
     web-console (2.3.0)
       activemodel (>= 4.0)
       binding_of_caller (>= 0.7.2)
@@ -200,6 +237,7 @@ DEPENDENCIES
   coffee-rails (~> 4.1.0)
   date_validator
   dotenv-rails
+  foreman
   jbuilder (~> 2.0)
   jquery-rails
   minitest-spec-rails
@@ -213,6 +251,10 @@ DEPENDENCIES
   simplecov
   spring
   turbolinks
+  twitter
   tzinfo-data
   uglifier (>= 1.3.0)
   web-console (~> 2.0)
+
+BUNDLED WITH
+   1.11.2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -115,6 +115,7 @@ GEM
       mime-types (>= 1.16, < 4)
     memoizable (0.4.2)
       thread_safe (~> 0.3, >= 0.3.1)
+    metaclass (0.0.4)
     method_source (0.8.2)
     mime-types (3.1)
       mime-types-data (~> 3.2015)
@@ -124,6 +125,8 @@ GEM
     minitest-spec-rails (5.4.0)
       minitest (~> 5.0)
       rails (>= 4.1)
+    mocha (1.1.0)
+      metaclass (~> 0.0.1)
     multi_json (1.12.1)
     multipart-post (2.0.0)
     naught (1.1.0)
@@ -241,6 +244,7 @@ DEPENDENCIES
   jbuilder (~> 2.0)
   jquery-rails
   minitest-spec-rails
+  mocha
   pg
   pry
   puma

--- a/app/controllers/admin_events_controller.rb
+++ b/app/controllers/admin_events_controller.rb
@@ -34,7 +34,7 @@ class AdminEventsController < ApplicationController
     @event.toggle(:approved)
     @event.save
     if @event.approved?
-      TwitterWorker.perform_async(@event.name, event_url(@event))
+      TwitterWorker.announce_event(@event)
     end
     redirect_to admin_url
   end

--- a/app/controllers/admin_events_controller.rb
+++ b/app/controllers/admin_events_controller.rb
@@ -33,6 +33,9 @@ class AdminEventsController < ApplicationController
   def approve
     @event.toggle(:approved)
     @event.save
+    if @event.approved?
+      TwitterWorker.perform_async(@event.name, event_url(@event))
+    end
     redirect_to admin_url
   end
 

--- a/app/workers/twitter_worker.rb
+++ b/app/workers/twitter_worker.rb
@@ -1,0 +1,7 @@
+class TwitterWorker
+  include Sidekiq::Worker
+  def perform(event_name, event_url)
+  	TWITTER_CLIENT.update("#{event_name} is a new event on #{event_url}!
+  		Check it out :)")
+  end
+end

--- a/app/workers/twitter_worker.rb
+++ b/app/workers/twitter_worker.rb
@@ -1,7 +1,22 @@
 class TwitterWorker
   include Sidekiq::Worker
+
+  def self.announce_event(event)
+    event_url = routes.event_url(event)
+    perform_async(event.name, event_url)
+  end
+
+  def self.routes
+    @routes ||= Class.new {
+      include Rails.application.routes.url_helpers
+
+      def default_url_options
+        Rails.configuration.x.worker_routes.default_url_options
+      end
+    }.new
+  end
+
   def perform(event_name, event_url)
-  	TWITTER_CLIENT.update("#{event_name} is a new event on #{event_url}!
-  		Check it out :)")
+    TWITTER_CLIENT.update("#{event_name} is a new event on #{event_url} ! Check it out :)")
   end
 end

--- a/app/workers/twitter_worker.rb
+++ b/app/workers/twitter_worker.rb
@@ -3,7 +3,7 @@ class TwitterWorker
 
   def self.announce_event(event)
     event_url = routes.event_url(event)
-    perform_async(event.name, event_url)
+    perform_async(event.name, event.deadline, event_url)
   end
 
   def self.routes
@@ -16,7 +16,7 @@ class TwitterWorker
     }.new
   end
 
-  def perform(event_name, event_url)
-    TWITTER_CLIENT.update("#{event_name} is a new event on #{event_url} ! Check it out :)")
+  def perform(event_name, event_deadline, event_url)
+    TWITTER_CLIENT.update("So great! #{event_name} is offering free diversity tickets! Apply until #{event_deadline} at #{event_url}!")
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -23,5 +23,10 @@ module DiversityTicketing
     config.active_job.queue_adapter = :sidekiq
     # Do not swallow errors in after_commit/after_rollback callbacks.
     config.active_record.raise_in_transactional_callbacks = true
+
+    # set default url options for mailers
+    config.action_mailer.default_url_options = {host: 'localhost'}
+    # set default url options for Sidekiq workers
+    config.x.worker_routes.default_url_options = {host: 'localhost'}
   end
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -75,8 +75,6 @@ Rails.application.configure do
     :authentication => :cram_md5, # or :plain for plain-text authentication
     :enable_starttls_auto => true
   }
-  config.action_mailer.default_url_options = { host: 'diversitytickets.org' }
-
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).
   config.i18n.fallbacks = true
@@ -91,4 +89,9 @@ Rails.application.configure do
   config.active_record.dump_schema_after_migration = false
 
   config.middleware.insert(0, RedirectWWW)
+
+  # set default url options for mailers
+  config.action_mailer.default_url_options = {host: 'diversitytickets.org', protocol: 'https'}
+  # set default url options for Sidekiq workers
+  config.x.worker_routes.default_url_options = {host: 'diversitytickets.org', protocol: 'https'}
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -41,4 +41,7 @@ Rails.application.configure do
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
+
+  # set default url options for Sidekiq workers
+  config.x.worker_routes.default_url_options = {host: 'test.host', protocol: 'https'}
 end

--- a/config/initializers/test_config.rb
+++ b/config/initializers/test_config.rb
@@ -1,0 +1,6 @@
+if Rails.env.test? || Rails.env.development?
+	ENV['TWITTER_CONSUMER_KEY'] ||= '123456'
+	ENV['TWITTER_CONSUMER_SECRET'] ||= '123456'
+	ENV['TWITTER_ACCESS_TOKEN'] ||= '1234556'
+	ENV['TWITTER_ACCESS_SECRET'] ||= '123456'
+end

--- a/config/initializers/twitter.rb
+++ b/config/initializers/twitter.rb
@@ -1,0 +1,7 @@
+TWITTER_CLIENT = Twitter::REST::Client.new do |config|
+  config.consumer_key        = ENV.fetch("TWITTER_CONSUMER_KEY")
+  config.consumer_secret     = ENV.fetch("TWITTER_CONSUMER_SECRET")
+  config.access_token        = ENV.fetch("TWITTER_ACCESS_TOKEN")
+  config.access_token_secret = ENV.fetch("TWITTER_ACCESS_SECRET")
+end
+

--- a/test/controllers/admin_events_controller_test.rb
+++ b/test/controllers/admin_events_controller_test.rb
@@ -24,4 +24,25 @@ class AdminEventsControllerTest < ActionController::TestCase
 
     assert_response :success
   end
+
+  # The following test should
+  # - make an event
+  # - make an admin user
+  # - sign in as that user
+  # - approve the event
+  # - show the correct results: event is approved (default: unapproved)
+  # - check if a tweet was made
+  test 'approve action correctly approves event' do
+    event = make_event
+    user = make_user(admin: true)
+    sign_in_as(user)
+
+    TWITTER_CLIENT.expects(:update).once
+
+    post :approve, id: event.id
+
+    event.reload
+
+    assert_equal(true, event.approved?)
+  end
 end

--- a/test/controllers/admin_events_controller_test.rb
+++ b/test/controllers/admin_events_controller_test.rb
@@ -37,7 +37,7 @@ class AdminEventsControllerTest < ActionController::TestCase
     user = make_user(admin: true)
     sign_in_as(user)
 
-    TWITTER_CLIENT.expects(:update).once
+    TwitterWorker.expects(:announce_event).with(event).once
 
     post :approve, id: event.id
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -9,6 +9,7 @@ require File.expand_path('../../config/environment', __FILE__)
 require 'rails/test_help'
 require 'minitest/autorun'
 require 'clearance/test_unit'
+require 'mocha/mini_test'
 
 require 'sidekiq/testing'
 Sidekiq::Testing.inline!
@@ -105,3 +106,4 @@ module Minitest::Assertions
     refute_equal [], event.errors[attribute]
   end
 end
+

--- a/test/workers/twitter_worker_test.rb
+++ b/test/workers/twitter_worker_test.rb
@@ -1,0 +1,11 @@
+require 'test_helper'
+
+class TwitterWorkerTest < ActiveSupport::TestCase
+
+	test 'it sends a tweet correctly' do
+		event = Event.new(name: "Awesome Event", id: 101)
+		TWITTER_CLIENT.expects(:update).with("Awesome Event is a new event on https://test.host/events/101 ! Check it out :)").once
+
+		TwitterWorker.announce_event(event)
+	end
+end

--- a/test/workers/twitter_worker_test.rb
+++ b/test/workers/twitter_worker_test.rb
@@ -2,10 +2,9 @@ require 'test_helper'
 
 class TwitterWorkerTest < ActiveSupport::TestCase
 
-	test 'it sends a tweet correctly' do
-		event = Event.new(name: "Awesome Event", id: 101)
-		TWITTER_CLIENT.expects(:update).with("Awesome Event is a new event on https://test.host/events/101 ! Check it out :)").once
-
-		TwitterWorker.announce_event(event)
-	end
+  test 'it sends a tweet correctly' do
+    event = Event.new(name: "Awesome Event", id: 101, deadline: 2.weeks.from_now)
+    TWITTER_CLIENT.expects(:update).with("So great! Awesome Event is offering free diversity tickets! Apply until #{2.weeks.from_now.to_date} at https://test.host/events/101!").once
+    TwitterWorker.announce_event(event)
+  end
 end


### PR DESCRIPTION
addresses #200 
- [x] tests still missing
- [x] other tests currently failing because tokens are not adapted for test environment
- [x] use mocking to test Twitter integration to fix this ^
- [x] create Twitter application for Twitter account that should send out the tweets, add tokens as ENVs to Heroku before deploying
- [x] @anikalindtner Please review the tweet text :)