### PR TITLE
past_events list now has also styling

### DIFF
--- a/app/views/events/index_past.html.erb
+++ b/app/views/events/index_past.html.erb
@@ -1,8 +1,8 @@
 <p>These events provided diversity tickets in the past. Many thanks to the organizers.</p>
 <% @events.each do |event| %>
-  <div class="event">
+  <div class="box event">
     <h3><%= link_to event.name, event_path(:id => event.id) %></h3>
-    <p><%= event.description %></p>
+    <p class="markdownize"><%= event.description %></p>
   </div>
 <% end %>
 


### PR DESCRIPTION
issue  #206 should now be solved. Past events list now also has styling. Should look like in attached screenshot now. 

Maybe you can take a quick look @lislis  :)

![diversitytickets-past_events_styling](https://cloud.githubusercontent.com/assets/2095123/15807097/55b0bb72-2b54-11e6-817c-e749463a554a.jpg)
