### PR TITLE
fixed lonely dots on frontpage (mobile)

### DIFF
--- a/app/assets/stylesheets/front.sass
+++ b/app/assets/stylesheets/front.sass
@@ -35,11 +35,12 @@ $yellow-em: #f7d56b
   a:hover
     border-bottom: none
 
-
 .front-title
-  font-size: 40px
+  font-size: 36px
   color: $grey-front
   font-weight: 300
+  @media (min-width: $small)
+    font-size: 40px
   @media (min-width: $medium)
     font-size: 50px
 
@@ -90,11 +91,17 @@ $yellow-em: #f7d56b
   font-style: normal
 
 .em--red
-  +coloredEm($red-em)
-  +wobble(1700ms)
+  border-bottom: solid 5px $red-em
+  @media (min-width: $small)
+    border-bottom: none
+    +coloredEm($red-em)
+    +wobble(1700ms)
 .em--yellow
-  +coloredEm($yellow-em)
-  +wobble(1500ms)
+  border-bottom: solid 5px $yellow-em
+  @media (min-width: $small)
+    border-bottom: none
+    +coloredEm($yellow-em)
+    +wobble(1500ms)
 
 
 @keyframes wobble

--- a/app/views/home/home.html.erb
+++ b/app/views/home/home.html.erb
@@ -1,5 +1,5 @@
-<h1 class="front-title">We help events reach a <em class="em--yellow">more diverse</em> audience. And we help you to <em class="em--yellow">find these events</em>.</h1>
-<h2 class="front-title">Because <em class="em--red">diversity</em> is what <em class="em--red">makes communities whole</em>.</h2>
+<h1 class="front-title">We help events reach a <em class="em--yellow">more diverse</em> audience. And we help you to <em class="em--yellow">find these events.</em></h1>
+<h2 class="front-title">Because <em class="em--red">diversity</em> is what <em class="em--red">makes communities whole.</em></h2>
 
 <div class="front-cta">
   <%= link_to events_path, class:"front-apply attendee" do %>

--- a/app/views/home/home.html.erb
+++ b/app/views/home/home.html.erb
@@ -1,5 +1,5 @@
-<h1 class="front-title">We help events reach a <em class="em--yellow">more diverse</em> audience. And we help you to <em class="em--yellow">find these events.</em></h1>
-<h2 class="front-title">Because <em class="em--red">diversity</em> is what <em class="em--red">makes communities whole.</em></h2>
+<h1 class="front-title">We help events reach a <em class="em--yellow">more diverse</em> audience. And we help you to <em class="em--yellow">find these events</em>.</h1>
+<h2 class="front-title">Because <em class="em--red">diversity</em> is what <em class="em--red">makes communities whole</em>.</h2>
 
 <div class="front-cta">
   <%= link_to events_path, class:"front-apply attendee" do %>


### PR DESCRIPTION
(issue #192) In the mobile version some dots would break to the next line on the frontpage's headlines. Should now look fine. @lislis please check. :)


![diversitytickets 2016-06-12 19-53-34](https://cloud.githubusercontent.com/assets/2095123/15992895/e4a8cf8a-30d7-11e6-9853-0d24cced5581.jpg)
