### PR TITLE
require js files for markdown

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -20,4 +20,5 @@
 //= require jquery.fileupload-process.js
 //= require jquery.fileupload-image.js
 //= require events.js
-
+//= require markdown.js
+//= require marked.min.js


### PR DESCRIPTION
...because of previous switch from require_tree to explicit require