### PR TITLE
Fix events listing (past/upcoming)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -59,6 +59,10 @@ group :development do
   gem 'dotenv-rails'
 end
 
+group :test do
+  gem 'minitest-spec-rails'
+end
+
 gem 'simplecov', require: false, group: :test
 
 gem 'tzinfo-data', platforms: [:mingw, :mswin]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -101,6 +101,9 @@ GEM
     mime-types-data (3.2016.0521)
     mini_portile2 (2.1.0)
     minitest (5.9.0)
+    minitest-spec-rails (5.4.0)
+      minitest (~> 5.0)
+      rails (>= 4.1)
     multi_json (1.12.1)
     nokogiri (1.6.8)
       mini_portile2 (~> 2.1.0)
@@ -199,6 +202,7 @@ DEPENDENCIES
   dotenv-rails
   jbuilder (~> 2.0)
   jquery-rails
+  minitest-spec-rails
   pg
   pry
   puma

--- a/app/controllers/admin_events_controller.rb
+++ b/app/controllers/admin_events_controller.rb
@@ -5,9 +5,9 @@ class AdminEventsController < ApplicationController
 
 	def index
     @categorized_events = {
-      "Unapproved Events" => Event.unapproved,
+      "Unapproved Events" => Event.unapproved.upcoming,
       "Approved Events" => Event.approved.upcoming,
-      "Past Events"=> Event.approved.past
+      "Past Events"=> Event.past
     }
   end
 

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -9,7 +9,7 @@ class Event < ActiveRecord::Base
   validates :organizer_email_confirmation, presence: true, on: :create
   validates :website, :code_of_conduct, format: { with: /(http|https):\/\/.+\..+/ }
   validates :number_of_tickets, numericality: { only_integer: true, greater_than_or_equal_to: 1 }, presence: true
-  
+
   def self.approved
     where(approved: true)
   end
@@ -19,7 +19,7 @@ class Event < ActiveRecord::Base
   end
 
   def self.upcoming
-    where('end_date > ?', DateTime.now)
+    where('end_date >= ?', DateTime.now)
   end
 
   def self.past

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -18,8 +18,8 @@ class Event < ActiveRecord::Base
     where(approved: false)
   end
 
-  def self.upcoming
-    where('end_date >= ?', DateTime.now)
+  def self.upcoming(now = DateTime.now)
+    where('end_date >= ?', now)
   end
 
   def self.past

--- a/test/controllers/events_controller_test.rb
+++ b/test/controllers/events_controller_test.rb
@@ -146,20 +146,4 @@ class EventsControllerTest < ActionController::TestCase
 
     assert_select ".event", {count: 1}, "This page must contain an event."
   end
-
-  test "index action does not show event with end_date in the past" do
-    @event = make_event(approved: true, start_date: 3.weeks.ago, end_date: 2.weeks.ago)
-
-    get :index
-
-    assert_select ".event", {count: 0}, "This page must not contain an event."
-  end
-
-  test "index action shows event with end_date today" do
-    @event = make_event(approved: true, start_date: 1.day.ago, end_date: Date.today)
-
-    get :index
-
-    assert_select ".event", {count: 1}, "This page must contain an event."
-  end
 end

--- a/test/controllers/events_controller_test.rb
+++ b/test/controllers/events_controller_test.rb
@@ -2,7 +2,6 @@ require 'test_helper'
 
 class EventsControllerTest < ActionController::TestCase
   test "successfully creates event and sends email" do
-    #create admin
     make_admin
 
     post :create, event: make_event_form_params
@@ -18,26 +17,26 @@ class EventsControllerTest < ActionController::TestCase
   end
 
   test "index action shows only approved events" do
-  	approved_event = make_event(approved: true)
-  	unapproved_event = make_event(name: 'Other')
+    approved_event = make_event(approved: true)
+    unapproved_event = make_event(name: 'Other')
 
-  	get :index
+    get :index
 
-  	assert_select "h3", {count: 1, text: approved_event.name}
+    assert_select "h3", {count: 1, text: approved_event.name}
 
-  	assert(css_select("h3").none? { |element| element.text == unapproved_event.name })
+    assert(css_select("h3").none? { |element| element.text == unapproved_event.name })
   end
 
   test "index action shows only future events" do
- 		future_event = make_event(approved: true)
- 		past_event = make_event(start_date: 1.week.ago, end_date: 1.week.ago, deadline: 2.weeks.ago, approved: true, name: 'Other')
+    future_event = make_event(approved: true)
+    past_event = make_event(start_date: 1.week.ago, end_date: 1.week.ago, deadline: 2.weeks.ago, approved: true, name: 'Other')
 
- 		get :index
+    get :index
 
-  	assert_select "h3", {count: 1, text: future_event.name}
+    assert_select "h3", {count: 1, text: future_event.name}
 
-  	assert(css_select("h3").none? { |element| element.text == past_event.name })
- 	end
+    assert(css_select("h3").none? { |element| element.text == past_event.name })
+  end
 
   test "index action shows link to past events if there are past events" do
     make_event(start_date: 1.week.ago, end_date: 1.week.ago, deadline: 2.weeks.ago, approved: true, name: 'Other')
@@ -89,7 +88,7 @@ class EventsControllerTest < ActionController::TestCase
 
     post :create, event: params
 
-    assert_equal false, Event.last.application_process == 'selection_by_organizer'   
+    assert_equal false, Event.last.application_process == 'selection_by_organizer'
   end
 
   test "index action has apply link for event with deadline in the future" do
@@ -138,5 +137,29 @@ class EventsControllerTest < ActionController::TestCase
     get :show, :id => @past_event.id
 
     assert_select "a", {count: 0, text: "Apply"}, "This page should not contain 'Apply' link"
+  end
+
+  test "index action shows event with end_date in the future" do
+    @event = make_event(approved: true, start_date: 1.weeks.from_now, end_date: 2.weeks.from_now)
+
+    get :index
+
+    assert_select ".event", {count: 1}, "This page must contain an event."
+  end
+
+  test "index action does not show event with end_date in the past" do
+    @event = make_event(approved: true, start_date: 3.weeks.ago, end_date: 2.weeks.ago)
+
+    get :index
+
+    assert_select ".event", {count: 0}, "This page must not contain an event."
+  end
+
+  test "index action shows event with end_date today" do
+    @event = make_event(approved: true, start_date: 1.day.ago, end_date: Date.today)
+
+    get :index
+
+    assert_select ".event", {count: 1}, "This page must contain an event."
   end
 end

--- a/test/models/event_test.rb
+++ b/test/models/event_test.rb
@@ -16,7 +16,6 @@ class EventTest < ActiveSupport::TestCase
       event = Event.new(deadline: Date.new(2016, 4, 8))
       assert_equal event.deadline_as_time, ActiveSupport::TimeZone["Pacific Time (US & Canada)"].local(2016, 4, 9, 0, 0, 0)
     end
-
   end
 
   describe "validating organizer_email" do
@@ -83,6 +82,20 @@ class EventTest < ActiveSupport::TestCase
 
         assert_attribute_invalid(event, :application_link)
       end
+    end
+  end
+
+  describe "upcoming events" do
+    it "gets event with enddate on the same day" do
+      make_event(start_date: "2016-07-24", end_date: "2016-07-25")
+
+      assert_equal Event.upcoming("2016-07-25 23:59:59").length, 1
+    end
+
+    it " doesn't get event with enddate on the day before" do
+      make_event(start_date: "2016-07-24", end_date: "2016-07-25")
+
+      assert_equal Event.upcoming("2016-07-26 00:00:00").length, 0
     end
   end
 end


### PR DESCRIPTION
Just noticed today that RuhrJS was missing from production. This was due to the fact, that on the actual end date (today) it is not listed under upcoming or past.

I decided to get events on the end date for upcoming events. Next day it will go to past events.

Then I saw that in admin index, past events list only approved past events and I thought it doesn't make sense to list only the approved ones there so I changed that.