### PR TITLE
adjust event sorting, show disabled Apply buttons

### DIFF
--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -273,6 +273,21 @@ a {
   &:before {
     content: none !important;
   }
+  &:disabled {
+    background-color: lighten($grey-mid, 15);
+    pointer-events: none;
+  }
+}
+
+.button_to {
+  display: inline-block;
+}
+
+.hint {
+  color: lighten($grey-dark, 10);
+  margin-left: .4em;
+  font-size: 12px;
+  vertical-align: bottom;
 }
 
 .footer {

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -3,8 +3,9 @@ class EventsController < ApplicationController
   before_action :set_s3_direct_post, only: [:new, :preview, :edit, :create, :update]
 
   def index
-    @events = Event.approved.upcoming
-    @past_events = Event.approved.past
+    @open_events   = Event.approved.upcoming.open.order(:deadline)
+    @closed_events = Event.approved.upcoming.closed.order(:deadline)
+    @past_events   = Event.approved.past
   end
 
   def index_past

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -22,12 +22,24 @@ class Event < ActiveRecord::Base
     where('end_date >= ?', now)
   end
 
-  def self.past
-    where('end_date < ?', DateTime.now)
+  def self.past(now = DateTime.now)
+    where('end_date < ?', now)
+  end
+
+  def self.open(now = DateTime.now)
+    where('deadline >= ?', now)
+  end
+
+  def self.closed(now = DateTime.now)
+    where('deadline < ?', now)
   end
 
   def open?
     deadline_as_time >= Time.now
+  end
+
+  def closed?
+    deadline_as_time < Time.now
   end
 
   def deadline_as_time

--- a/app/views/events/_index_list_item.erb
+++ b/app/views/events/_index_list_item.erb
@@ -1,13 +1,17 @@
 <div class="box event">
   <h3>
     <div class="conflogo--medium"><%= event_image event %></div>
-    <%= link_to event.name, event_path(:id => event.id) %></h3>
+    <%= link_to event.name, event_path(:id => event.id) %>
+  </h3>
   <p class="markdownize"><%= event.description %></p>
-  <% if event.open? %>
-    <% if event.application_process == 'application_by_organizer' %>
-      <%= link_to "Apply at #{event.name}", event.application_link, class:'btn btn-save btn-external' %>
-    <% else %>
-      <%= link_to 'Apply', new_event_application_path(:event_id => event.id), class:'btn btn-save' %>
-    <% end %>
+
+  <% if event.application_process == 'application_by_organizer' %>
+    <%= button_to "Apply at #{event.name}", event.application_link, class:"btn btn-save btn-external", disabled: event.closed? %>
+  <% else %>
+    <%= button_to 'Apply', new_event_application_path(:event_id => event.id), class: "btn btn-save", disabled: event.closed? %>
+  <% end %>
+
+  <% if event.closed? %>
+    <span class="hint">Application deadline passed</span>
   <% end %>
 </div>

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -9,14 +9,14 @@
 <% else %>
 
   <% if @open_events.any? %>
-    <h2>Application open</h2>
+    <h2>Open for applications</h2>
     <% @open_events.each do |event| %>
       <%= render partial: "index_list_item", locals: { event: event } %>
     <% end %>
   <% end %>
 
   <% if @closed_events.any? %>
-    <h2>Application closed</h2>
+    <h2>Closed for applications</h2>
     <% @closed_events.each do |event| %>
       <%= render partial: "index_list_item", locals: { event: event } %>
     <% end %>

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -1,18 +1,27 @@
-<% if @events.empty? %>
+<% if @open_events.empty? && @closed_events.empty? %>
 
-<div class="events-empty">
-  <h2>We currently have no events lined up.</h2>
-  <p>But we'll add new ones soon!<p>
-  <p>You can <%=link_to 'submit your own conference', new_event_path %> now or browse through <%= link_to 'past events', past_events_path if @past_events.any? %>.</p>
-</div>
+  <div class="events-empty">
+    <h2>We currently have no events lined up.</h2>
+    <p>But we'll add new ones soon!</p>
+    <p>You can <%=link_to 'submit your own conference', new_event_path %> now or browse through <%= link_to 'past events', past_events_path if @past_events.any? %>.</p>
+  </div>
 
 <% else %>
 
-  <% @events.each do |event| %>
+  <% if @open_events.any? %>
+    <h2>Application open</h2>
+    <% @open_events.each do |event| %>
+      <%= render partial: "index_list_item", locals: { event: event } %>
+    <% end %>
+  <% end %>
 
-    <%= render partial: "index_list_item", locals: { event: event } %>
-
+  <% if @closed_events.any? %>
+    <h2>Application closed</h2>
+    <% @closed_events.each do |event| %>
+      <%= render partial: "index_list_item", locals: { event: event } %>
+    <% end %>
   <% end %>
 
   <%= link_to 'Show past events', past_events_path if @past_events.any? %>
+
 <% end %>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -4,12 +4,12 @@
 
 <%= render :partial => "events/event" %>
 
-<% if @event.open? %>
-  <% if @event.application_process == 'application_by_organizer' %>
-    <%= link_to "Apply at #{@event.name}", @event.application_link, class:'btn btn-save btn-external' %><br>
-  <% else %>
-    <%= link_to 'Apply', new_event_application_path(params[:id]), class:'btn btn-save' %><br>
-  <% end %>
+<% if @event.application_process == 'application_by_organizer' %>
+  <%= button_to "Apply at #{@event.name}", @event.application_link, class:'btn btn-save btn-external', disabled: @event.closed? %>
 <% else %>
-  <strong>Sorry, application for <%= @event.name %> is closed.</strong>
+  <%= button_to 'Apply', new_event_application_path(params[:id]), class:'btn btn-save', disabled: @event.closed? %>
+<% end %>
+
+<% if @event.closed? %>
+  <span class="hint">Sorry, application for <%= @event.name %> is closed.</span>
 <% end %>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -11,5 +11,5 @@
 <% end %>
 
 <% if @event.closed? %>
-  <span class="hint">Sorry, application for <%= @event.name %> is closed.</span>
+  <span class="hint">Sorry, applications for <%= @event.name %> are closed.</span>
 <% end %>

--- a/test/controllers/events_controller_test.rb
+++ b/test/controllers/events_controller_test.rb
@@ -96,7 +96,7 @@ class EventsControllerTest < ActionController::TestCase
 
     get :index
 
-    assert_select "a", {count: 1, text: "Apply"}, "This page must contain 'Apply' link"
+    assert_select ".button_to", {count: 1, value: "Apply", disabled: false}, "This page must contain 'Apply' link"
   end
 
   test "index action has apply link for event where deadline is today" do
@@ -104,7 +104,7 @@ class EventsControllerTest < ActionController::TestCase
 
     get :index
 
-    assert_select "a", {count: 1, text: "Apply"}, "This page must contain 'Apply' link"
+    assert_select ".button_to", {count: 1, value: "Apply", disabled: false}, "This page must contain 'Apply' link"
   end
 
   test "index action has no apply link for event with deadline in the past" do
@@ -112,7 +112,7 @@ class EventsControllerTest < ActionController::TestCase
 
     get :index
 
-    assert_select "a", {count: 0, text: "Apply"}, "This page should not contain 'Apply' link"
+    assert_select ".button_to", {count: 0, value: "Apply"}, "This page should not contain 'Apply' button"
   end
 
   test "show action has apply link for event with deadline in the future" do
@@ -120,7 +120,7 @@ class EventsControllerTest < ActionController::TestCase
 
     get :show, :id => @event.id
 
-    assert_select "a", {count: 1, text: "Apply"}, "This page must contain 'Apply' link"
+    assert_select ".button_to", {count: 1, value: "Apply", disabled: false}, "This page must contain 'Apply' button"
   end
 
   test "show action has apply link for event where deadline is today" do
@@ -128,7 +128,7 @@ class EventsControllerTest < ActionController::TestCase
 
     get :show, :id => @event.id
 
-    assert_select "a", {count: 1, text: "Apply"}, "This page must contain 'Apply' link"
+    assert_select ".button_to", {count: 1, value: "Apply", disabled: false}, "This page must contain 'Apply' button"
   end
 
   test "show action has no apply link for event with deadline in the past" do
@@ -136,7 +136,7 @@ class EventsControllerTest < ActionController::TestCase
 
     get :show, :id => @past_event.id
 
-    assert_select "a", {count: 0, text: "Apply"}, "This page should not contain 'Apply' link"
+    assert_select ".button_to", {count: 1, value: "Apply", disabled: true}, "This page should contain disabled 'Apply' button"
   end
 
   test "index action shows event with end_date in the future" do

--- a/test/models/event_test.rb
+++ b/test/models/event_test.rb
@@ -85,7 +85,7 @@ class EventTest < ActiveSupport::TestCase
     end
   end
 
-  describe "upcoming events" do
+  describe "upcoming" do
     it "gets event with enddate on the same day" do
       make_event(start_date: "2016-07-24", end_date: "2016-07-25")
 
@@ -96,6 +96,48 @@ class EventTest < ActiveSupport::TestCase
       make_event(start_date: "2016-07-24", end_date: "2016-07-25")
 
       assert_equal Event.upcoming("2016-07-26 00:00:00").length, 0
+    end
+  end
+
+  describe "past" do
+    it "doesn't get event with enddate on the same day" do
+      make_event(start_date: "2016-07-24", end_date: "2016-07-25")
+
+      assert_equal Event.past("2016-07-25 23:59:59").length, 0
+    end
+
+    it "gets event with enddate on the day before" do
+      make_event(start_date: "2016-07-24", end_date: "2016-07-25")
+
+      assert_equal Event.past("2016-07-26 00:00:00").length, 1
+    end
+  end
+
+  describe "open" do
+    it "gets event with deadline on the same day" do
+      make_event(deadline: "2016-07-25")
+
+      assert_equal Event.open("2016-07-25 23:59:59").length, 1
+    end
+
+    it "doesn't get event with deadline on the day before" do
+      make_event(deadline: "2016-07-25")
+
+      assert_equal Event.open("2016-07-26 00:00:00").length, 0
+    end
+  end
+
+  describe "closed" do
+    it "doesn't get event with deadline on the same day" do
+      make_event(deadline: "2016-07-25")
+
+      assert_equal Event.closed("2016-07-25 23:59:59").length, 0
+    end
+
+    it "gets event with deadline on the day before" do
+      make_event(deadline: "2016-07-25")
+
+      assert_equal Event.closed("2016-07-26 00:00:00").length, 1
     end
   end
 end


### PR DESCRIPTION
sorts events into 2 categories, open and closed: events where the
deadline closes the soonest are at the top and events with already closed
deadline move to the bottom (#238);
Apply button will now show even if the application is closed, the button
will be disabled and show a hint that the application is closed (#217)