### PR TITLE
adds target blank to event site to stay on the diversitytickets website

### DIFF
--- a/app/assets/stylesheets/button.sass
+++ b/app/assets/stylesheets/button.sass
@@ -6,6 +6,10 @@
   color: #ffffff !important
   line-height: 1.3 !important
   height: 36px
+  max-width: 17em
+  white-space: nowrap
+  overflow: hidden
+  text-overflow: ellipsis
   &:hover,
   &:active
     color: #ffffff
@@ -54,7 +58,7 @@
   margin-left: .4em
   font-size: 12px
   vertical-align: bottom
-  
-.btn:first-of-type:not(:only-child) 
+
+.btn:first-of-type:not(:only-child)
   margin-right: 1em
 

--- a/app/views/events/_event.html.erb
+++ b/app/views/events/_event.html.erb
@@ -16,18 +16,18 @@
 <% if @event.twitter_handle.present? %>
   <div class="detail-pair">
     <strong>Twitter</strong>
-    <%= link_to "@#{@event.twitter_handle}", "https://twitter.com/#{@event.twitter_handle}" %>
+    <%= link_to "@#{@event.twitter_handle}", "https://twitter.com/#{@event.twitter_handle}", target: "_blank" %>
   </div>
 <% end %>
 
 <div class="detail-pair">
   <strong>Website</strong>
-  <%= link_to @event.website, "#{@event.website}" %>
+  <%= link_to @event.website, "#{@event.website}", target: "_blank" %>
 </div>
 
 <div class="detail-pair">
   <strong>Code of Conduct link</strong>
-  <%= link_to @event.code_of_conduct, "#{@event.code_of_conduct}" %>
+  <%= link_to @event.code_of_conduct, "#{@event.code_of_conduct}", target: "_blank" %>
 </div>
 
 <div class="detail-pair">
@@ -90,7 +90,7 @@
         We are handling the selection process ourselves, but the application process will be handled by diversitytickets.org. We will not share the privacy, details, and answers of any applicant with third parties, including those who sponsor the diversity tickets.
       <% elsif @event.application_process == 'application_by_organizer' %>
         We are handling both the selection and application process and only want our event listed on this site. Applicants have to apply through our site / app:
-        <%= link_to @event.application_link, "#{@event.application_link}" %>
+        <%= link_to @event.application_link, "#{@event.application_link}", target: "_blank" %>
       <% end %>
     </div>
   </section>


### PR DESCRIPTION
If you would like to apply for a diversity ticket, you would like to take a look to the conference website without leaving the applying website. 