### PR TITLE
issue #283 - twitter handle fix

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -97,7 +97,8 @@ class EventsController < ApplicationController
         :description, :name, :logo, :start_date, :end_date, :ticket_funded,
         :accommodation_funded, :travel_funded, :deadline, :number_of_tickets,
         :website, :code_of_conduct, :city, :country, :applicant_directions,
-        :data_protection_confirmation, :application_link, :application_process
+        :data_protection_confirmation, :application_link, :application_process,
+        :twitter_handle
       ]
     end
 


### PR DESCRIPTION
Adding `:twitter_handle` to the `permitted_params_for_event_organizers` solves the issue

![image](https://cloud.githubusercontent.com/assets/26172652/25916819/4cdaafa8-35c6-11e7-9528-c006e5c0e678.png)
