### PR TITLE
Improve admin mailers

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -13,6 +13,10 @@ class Event < ActiveRecord::Base
   validates :number_of_tickets, numericality: { only_integer: true, greater_than_or_equal_to: 1 }, presence: true
   validates :twitter_handle, format: { with: /\A@?\w+\z/ }, allow_nil: true
 
+  def self.application_via_diversitytickets
+    where.not(application_process: 'application_by_organizer')
+  end
+
   def self.approved
     where(approved: true)
   end

--- a/app/services/deadline_passed_mail_service.rb
+++ b/app/services/deadline_passed_mail_service.rb
@@ -1,6 +1,6 @@
 class DeadlinePassedMailService
   def self.send_deadline_passed_mail
-    Event.deadline_yesterday.each do |event|
+    Event.application_via_diversitytickets.deadline_yesterday.each do |event|
       User.admin.each do |user|
         AdminMailer.passed_event_deadline(event, user.email).deliver_later
       end

--- a/app/views/admin_mailer/submitted_event.text.erb
+++ b/app/views/admin_mailer/submitted_event.text.erb
@@ -1,4 +1,7 @@
 Dear Admin,
 
-the new event <%= @event.name %> has been submitted. 
+the new event <%= @event.name %> has been submitted.
 
+Follow the link below to view details:
+
+<%= event_admin_url(@event) %>

--- a/app/views/admin_mailer/upcoming_event_deadline.text.erb
+++ b/app/views/admin_mailer/upcoming_event_deadline.text.erb
@@ -1,3 +1,7 @@
 Dear Admin,
 
 the deadline for <%= @event.name %> is only two days away!
+
+Follow the link below to view details:
+
+<%= event_admin_url(@event) %>

--- a/test/controllers/events_controller_test.rb
+++ b/test/controllers/events_controller_test.rb
@@ -5,6 +5,8 @@ class EventsControllerTest < ActionController::TestCase
     admin_user = make_admin
     sign_in_as(admin_user)
 
+    ActionMailer::Base.deliveries.clear
+
     post :create, event: make_event_form_params
 
     assert_equal "Thank you for submitting Event. We will review it shortly.", flash[:notice]
@@ -195,7 +197,7 @@ class EventsControllerTest < ActionController::TestCase
     post :create, event: event_params
 
     event = Event.find_by(name: "MonsterConf")
-    
+
     assert_equal user.id, event.organizer_id
   end
 

--- a/test/services/deadline_passed_mail_service_test.rb
+++ b/test/services/deadline_passed_mail_service_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 
 class DeadlinePassedMailServiceTest < ActiveSupport::TestCase
-  describe "sending emails about events with passed deadlines to admins"  do
+  describe "sending emails about events with passed deadlines to admins" do
     it "send emails about right events to the right people" do
       make_event(deadline: 1.days.ago, name: "Valid Event")
       make_event(deadline: 1.week.ago)
@@ -17,6 +17,33 @@ class DeadlinePassedMailServiceTest < ActiveSupport::TestCase
       mail = mails.first
       assert_equal ["good@example.com"], mail.to
       assert mail.subject =~ /Valid Event/
+    end
+
+    it "excludes events that are listings (applications & selection are handled by organizer)" do
+      make_event(
+        deadline: 1.days.ago, name: "Valid Event",
+        application_process: "selection_by_travis"
+      )
+      make_event(
+        deadline: 1.days.ago, name: "Valid Event",
+        application_process: "selection_by_organizer"
+      )
+      make_event(
+        deadline: 1.days.ago, name: "Listed Event",
+        application_process: "application_by_organizer", application_link: "https://myconf.com"
+      )
+      make_admin
+
+      ActionMailer::Base.deliveries.clear
+
+      DeadlinePassedMailService.send_deadline_passed_mail
+
+      mails = ActionMailer::Base.deliveries
+      assert_equal 2, mails.length
+      mail1 = mails.first
+      mail2 = mails.last
+      assert mail1.subject =~ /Valid Event/
+      assert mail2.subject =~ /Valid Event/
     end
   end
 end


### PR DESCRIPTION
- send 'deadline passed' emails not for events that are listed (no selection or sending out CSV is needed)
- add link to admin event view to 'new event submitted' and 'deadline in 2 days' emails

closes #285 