### PR TITLE
Break words in .detail-pair to prevent overflow

### DIFF
--- a/app/assets/stylesheets/box.sass
+++ b/app/assets/stylesheets/box.sass
@@ -36,6 +36,7 @@
   font-size: 18px
   color: #232323
   margin-top: 20px
+  word-break: break-all
 
 .detail-pair > strong
   display: block


### PR DESCRIPTION
When there's a long URL in the user-submitted content, it can look odd. I think this line of Sass fixes it.

Before:
<img width="591" alt="before" src="https://user-images.githubusercontent.com/65193/31127298-c92835a8-a84e-11e7-8098-152266e9f055.png">

After:
<img width="601" alt="after" src="https://user-images.githubusercontent.com/65193/31127310-d428a820-a84e-11e7-9082-0e8590f34c96.png">
