### PR TITLE
Adds a redirection to the reset password page for users that have not encrypted passwords

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,7 +1,7 @@
 class SessionsController < Clearance::SessionsController
 
   def create
-    if params[:session][:password] && User.find_by(email: params[:session][:email]).encrypted_password === 'x'
+    if params[:session][:password] && User.find_by(email: params[:session][:email]).encrypted_password == 'x'
       redirect_to  new_password_path, flash: { :info => "Due to a security update from our side we kindly ask you to reset your password." }
 
     else @user = authenticate(params)

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,14 +1,19 @@
 class SessionsController < Clearance::SessionsController
 
   def create
-    @user = authenticate(params)
+    if params[:session][:password] && User.find_by(email: params[:session][:email]).encrypted_password === 'x'
+      redirect_to  new_password_path, flash: { :info => "Due to a security update from our side we kindly ask you to reset your password." }
 
-    sign_in(@user) do |status|
-      if status.success?
-        redirect_to params[:referer]
-      else
-        flash[:alert] = status.failure_message
-        render template: "sessions/new", status: :unauthorized
+    else @user = authenticate(params)
+
+      sign_in(@user) do |status|
+
+        if status.success?
+            redirect_to params[:referer]
+        else
+          flash[:alert] = status.failure_message
+          render template: "sessions/new", status: :unauthorized
+        end
       end
     end
   end


### PR DESCRIPTION
This PR aims to prevent the users that don't have encrypted passcodes to try to sign in. Previously we didn't allow them to sign in and the users couldn't recognize that they needed to reset their passwords in order to generate new ones.
In this PR we are redirecting them to the reset password page and showing an alert (info) informing them that they need to reset them.
Note: This is an edge case as most of the users already reseted their passwords.