### PR TITLE
Approve events in the show view

### DIFF
--- a/app/controllers/admin_events_controller.rb
+++ b/app/controllers/admin_events_controller.rb
@@ -37,7 +37,7 @@ class AdminEventsController < ApplicationController
     if @event.approved?
       TwitterWorker.announce_event(@event)
     end
-    redirect_to admin_url
+    redirect_to admin_url, notice: "#{@event.name} has been approved!"
   end
 
   def destroy

--- a/app/controllers/admin_events_controller.rb
+++ b/app/controllers/admin_events_controller.rb
@@ -36,8 +36,10 @@ class AdminEventsController < ApplicationController
     @event.save!
     if @event.approved?
       TwitterWorker.announce_event(@event)
+      redirect_to admin_url, notice: "#{@event.name} has been approved!"
+    else
+      redirect_to admin_url, notice: "#{@event.name} has been unapproved!"
     end
-    redirect_to admin_url, notice: "#{@event.name} has been approved!"
   end
 
   def destroy

--- a/app/views/admin_events/show.html.erb
+++ b/app/views/admin_events/show.html.erb
@@ -81,4 +81,6 @@
   <%= link_to "Edit event", edit_event_path(@event.id), class: "btn btn-edit" %>
   <%= link_to "Delete event", event_path(@event.id), method: :delete,
       data: {confirm: "Are you sure?"}, class: "btn btn-delete" %>
+  <%= link_to "Approve event", approve_admin_event_path(@event.id), method: :post,
+      class: "btn btn-save" %>
 </div>

--- a/test/integration/admin_event_details_test.rb
+++ b/test/integration/admin_event_details_test.rb
@@ -135,10 +135,7 @@ feature 'Admin Event Details' do
 
     assert page.has_content?("Approve event")
 
-    TWITTER_CLIENT.expects(:update).with(
-      "So great! Event is offering free diversity tickets! Apply before "\
-      "#{format_date(2.weeks.from_now)} at https://test.host/events/#{@event.id}!"
-    ).once
+    TWITTER_CLIENT.expects(:update).once
 
     click_link("Approve event")
 

--- a/test/integration/admin_event_details_test.rb
+++ b/test/integration/admin_event_details_test.rb
@@ -1,4 +1,5 @@
 require 'test_helper'
+include ApplicationHelper
 
 feature 'Admin Event Details' do
 
@@ -128,12 +129,18 @@ feature 'Admin Event Details' do
 
   test 'shows Approve event Button if event has not been approved' do
     sign_in_as_admin
+    @event.update_attributes(deadline: 2.weeks.from_now)
 
     visit admin_event_path(@event.id)
 
     assert page.has_content?("Approve event")
 
-    click_link('Approve event')
+    TWITTER_CLIENT.expects(:update).with(
+      "So great! Event is offering free diversity tickets! Apply before "\
+      "#{format_date(2.weeks.from_now)} at https://test.host/events/#{@event.id}!"
+    ).once
+
+    click_link("Approve event")
 
     assert page.has_content?("#{@event.name} has been approved!")
   end

--- a/test/integration/admin_event_details_test.rb
+++ b/test/integration/admin_event_details_test.rb
@@ -125,4 +125,16 @@ feature 'Admin Event Details' do
     assert page.has_content?("Approved Applications (0)")
     assert page.has_content?("Pending Applications (3)")
   end
+
+  test 'shows Approve event Button if event has not been approved' do
+    sign_in_as_admin
+
+    visit admin_event_path(@event.id)
+
+    assert page.has_content?("Approve event")
+
+    click_link('Approve event')
+
+    assert page.has_content?("#{@event.name} has been approved!")
+  end
 end


### PR DESCRIPTION
This PR adds an "Approve event" button to the application show view in order to make the life of Travis Foundation aka @alicetragedy easier.
It also adds a test that stubs the Twitter client so we can skip it and correctly test the button.