### PR TITLE
#341 adds flash.now to erase flash alert after redirect

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -11,7 +11,7 @@ class SessionsController < Clearance::SessionsController
         if status.success?
             redirect_to params[:referer]
         else
-          flash[:alert] = status.failure_message
+          flash.now[:alert] = status.failure_message
           render template: "sessions/new", status: :unauthorized
         end
       end


### PR DESCRIPTION
This PR makes sure that when a user signs in after a failed login the alert message "Bad email or password" is not being shown after successful login and redirect. Before this fix it would stay on the first page after successful login.

This is to address #341 