### PR TITLE
Displays a warning that there aren't any events to approve

### DIFF
--- a/app/views/admin_events/index.html.erb
+++ b/app/views/admin_events/index.html.erb
@@ -11,6 +11,10 @@
 
     <div class="admin">
       <ul class="admin-list">
+        <% if events.empty? %>
+        <p> We currently don't have any events to approve </p>
+        </ul>
+        <% else %>
         <% events.each do |event| %>
           <li>
             <p class="event-name">
@@ -48,6 +52,7 @@
                   class: "btn btn-save", title: "Download data" %>
             </p>
           </li>
+          <% end %>
         <% end %>
       </ul>
     </div>


### PR DESCRIPTION
For the admin view, everytime an Admin has approved all the events, the box of unapproved events still appears. This should be kept but we should let the Admin know that there aren't any events to approve. 
