### PR TITLE
Admin Statistics

### DIFF
--- a/app/controllers/admin_events_controller.rb
+++ b/app/controllers/admin_events_controller.rb
@@ -5,6 +5,8 @@ class AdminEventsController < ApplicationController
   before_action :require_admin
 
   def index
+    @events = Event.all
+    @new_users = User.all.created_last_30_days
     @categorized_events = {
       "Unapproved Events" => Event.unapproved.upcoming.order(:deadline),
       "Approved Events" => Event.approved.upcoming.order(:deadline),

--- a/app/controllers/admin_events_controller.rb
+++ b/app/controllers/admin_events_controller.rb
@@ -7,6 +7,7 @@ class AdminEventsController < ApplicationController
   def index
     @events = Event.all
     @new_users = User.all.created_last_30_days
+    @countries = Event.all.group_by(&:country).keys
     @categorized_events = {
       "Unapproved Events" => Event.unapproved.upcoming.order(:deadline),
       "Approved Events" => Event.approved.upcoming.order(:deadline),

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -53,6 +53,10 @@ class Event < ApplicationRecord
     where('deadline = ?', now + 2.days)
   end
 
+  def self.created_current_year(now = Time.zone.now)
+    where('created_at > ? AND created_at < ?', now.beginning_of_year, now.end_of_year )
+  end
+
   def open?
     deadline_as_time >= Time.now
   end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -98,13 +98,13 @@ class Event < ApplicationRecord
     !editable_by?(user)
   end
 
-  def self.number_of_events_per_country(country_rank)
-    @countries = Event.all.group_by(&:country)
-    @countries.map { |country, events| events.count }.sort[-country_rank]
+  def self.country_with_most_events(country_rank)
+    countries = Event.all.group_by(&:country)
+    @sorted_events = countries.sort_by{|country, events| events.count}
+    country = @sorted_events[-country_rank].first
   end
 
-  def self.country_with_most_events(country_rank)
-    most_events = self.number_of_events_per_country(country_rank)
-    @countries.select { |country, events| events.count == most_events }.keys[0]
+  def self.number_of_events_per_country(country_rank)
+    events_count = @sorted_events[-country_rank].last.count
   end
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -97,4 +97,14 @@ class Event < ApplicationRecord
   def uneditable_by?(user)
     !editable_by?(user)
   end
+
+  def self.number_of_events_per_country(country_rank)
+    @countries = Event.all.group_by(&:country)
+    @countries.map { |country, events| events.count }.sort[-country_rank]
+  end
+
+  def self.country_with_most_events(country_rank)
+    most_events = self.number_of_events_per_country(country_rank)
+    @countries.select { |country, events| events.count == most_events }.keys[0]
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,4 +7,8 @@ class User < ApplicationRecord
   def self.admin
   	where(admin: true)
   end
+
+  def self.created_last_30_days
+    where('created_at > ?', 31.days.ago)
+  end
 end

--- a/app/views/admin_events/index.html.erb
+++ b/app/views/admin_events/index.html.erb
@@ -7,20 +7,19 @@
       <li>Conferences since <%= Time.zone.now.year %>: <strong><%= @events.created_current_year.count %></strong></li>
       <li class="border">New users in the last 30 days: <strong><%= @new_users.count %></strong></li>
     </ul>
-    <% if Event.all.group_by(&:country).count > 2 %>
-      <ul class="admin-list">
-        <li>
-          Most conferences:
-          <strong>
-            <ol>
-              <li>1. <%= @events.country_with_most_events(1) %> (<%= @events.number_of_events_per_country(1)%>)</li>
-              <li>2. <%= @events.country_with_most_events(2) %> (<%= @events.number_of_events_per_country(2)%>)</li>
-              <li>3. <%= @events.country_with_most_events(3) %> (<%= @events.number_of_events_per_country(3)%>)</li>
-            </ol>
-          </strong>
-        </li>
-      </ul>
-    <% end %>
+    <ul class="admin-list">
+      <li>
+        Most conferences:
+        <strong>
+          <ol>
+            <% for index in 1..@countries.length%>
+            <% break if index > 3 %>
+            <li><%= index %>. <%=@events.country_with_most_events(index) %> (<%= @events.number_of_events_per_country(index)%>)</li>
+          <% end %>
+          </ol>
+        </strong>
+      </li>
+    </ul>
 </div>
 
 <p>

--- a/app/views/admin_events/index.html.erb
+++ b/app/views/admin_events/index.html.erb
@@ -7,18 +7,20 @@
       <li>Conferences since <%= Time.zone.now.year %>: <strong><%= @events.created_current_year.count %></strong></li>
       <li class="border">New users in the last 30 days: <strong><%= @new_users.count %></strong></li>
     </ul>
-    <ul class="admin-list">
-      <li>
-        Most conferences:
-        <strong>
-          <ol>
-            <li>1. <%= @events.country_with_most_events(1) %> (<%= @events.number_of_events_per_country(1)%>)</li>
-            <li>2. <%= @events.country_with_most_events(2) %> (<%= @events.number_of_events_per_country(2)%>)</li>
-            <li>3. <%= @events.country_with_most_events(3) %> (<%= @events.number_of_events_per_country(3)%>)</li>
-          </ol>
-        </strong>
-      </li>
-    </ul>
+    <% if Event.all.group_by(&:country).count > 2 %>
+      <ul class="admin-list">
+        <li>
+          Most conferences:
+          <strong>
+            <ol>
+              <li>1. <%= @events.country_with_most_events(1) %> (<%= @events.number_of_events_per_country(1)%>)</li>
+              <li>2. <%= @events.country_with_most_events(2) %> (<%= @events.number_of_events_per_country(2)%>)</li>
+              <li>3. <%= @events.country_with_most_events(3) %> (<%= @events.number_of_events_per_country(3)%>)</li>
+            </ol>
+          </strong>
+        </li>
+      </ul>
+    <% end %>
 </div>
 
 <p>

--- a/app/views/admin_events/index.html.erb
+++ b/app/views/admin_events/index.html.erb
@@ -1,5 +1,14 @@
 <h1>Admin Page</h1>
 
+<div class="box">
+  <h2>Statistics</h2>
+    <ul class="admin-list">
+      <li>Total Conferences: <strong><%= @events.count %></strong></li>
+      <li>Conferences since <%= Time.zone.now.year %>: <strong><%= @events.created_current_year.count %></strong></li>
+      <li>New Users in the last 30 days: <strong><%= @new_users.count %></strong></li>
+    </ul>
+</div>
+
 <p>
   <%= link_to 'Download Events Report', admin_path(format: :csv),
     class: "btn btn-save", title: "Download Events Report" %>

--- a/app/views/admin_events/index.html.erb
+++ b/app/views/admin_events/index.html.erb
@@ -5,7 +5,19 @@
     <ul class="admin-list">
       <li>Total Conferences: <strong><%= @events.count %></strong></li>
       <li>Conferences since <%= Time.zone.now.year %>: <strong><%= @events.created_current_year.count %></strong></li>
-      <li>New Users in the last 30 days: <strong><%= @new_users.count %></strong></li>
+      <li class="border">New users in the last 30 days: <strong><%= @new_users.count %></strong></li>
+    </ul>
+    <ul class="admin-list">
+      <li>
+        Most conferences:
+        <strong>
+          <ol>
+            <li>1. <%= @events.country_with_most_events(1) %> (<%= @events.number_of_events_per_country(1)%>)</li>
+            <li>2. <%= @events.country_with_most_events(2) %> (<%= @events.number_of_events_per_country(2)%>)</li>
+            <li>3. <%= @events.country_with_most_events(3) %> (<%= @events.number_of_events_per_country(3)%>)</li>
+          </ol>
+        </strong>
+      </li>
     </ul>
 </div>
 


### PR DESCRIPTION
This PR adds a statistics section with general information about diversity tickets conferences to the admin dashboard:
- Total number of conferences submitted on diversity tickets since the beginning
- Number of submitted conferences for the current calendar year to date
- Number of new user-signups over the past 30days
- Ranking of first three countries that hosted the most conferences including events-per-country count.