### PR TITLE
Terms and conditions check

### DIFF
--- a/app/controllers/applications_controller.rb
+++ b/app/controllers/applications_controller.rb
@@ -40,8 +40,13 @@ class ApplicationsController < ApplicationController
 
   def save_draft
     @application.skip_validation = true
+    if Application.find_by(id: @application.id)
+      message = "You have successfully saved your changes to the draft."
+    else
+      message = "You have successfully saved an application draft for #{@event.name}."
+    end
     if @application.save
-      redirect_to event_application_path(@event.id, @application.id), notice: "You have successfully saved an application draft for #{@event.name}."
+      redirect_to event_application_path(@event.id, @application.id), notice: message 
     end
   end
 

--- a/app/controllers/applications_controller.rb
+++ b/app/controllers/applications_controller.rb
@@ -19,11 +19,6 @@ class ApplicationsController < ApplicationController
     if @application.update(application_params) && params[:commit] == 'Apply Changes'
       redirect_to event_application_path(@event.id, @application.id),
       notice: "You have successfully updated your application for #{@event.name}."
-    elsif @application.update(application_params) && params[:commit] == 'Submit Application'
-      @application.update_attributes(submitted: true)
-      redirect_to user_applications_path(@application.applicant_id), notice: "You have successfully submitted an application for #{@event.name}."
-    elsif !@application.update(application_params) && params[:commit] == 'Submit Application'
-      render :show
     elsif params[:commit] == 'Save Changes'
       @application.skip_validation = true
       if @application.update(application_params)
@@ -32,6 +27,15 @@ class ApplicationsController < ApplicationController
       end
     else
       render :edit
+    end
+  end
+
+  def submit
+    if @application.update(application_params)
+      @application.update_attributes(submitted: true)
+      redirect_to user_applications_path(@application.applicant_id), notice: "You have successfully submitted an application for #{@event.name}."
+    else
+      render :show
     end
   end
 

--- a/app/controllers/applications_controller.rb
+++ b/app/controllers/applications_controller.rb
@@ -19,9 +19,17 @@ class ApplicationsController < ApplicationController
     if @application.update(application_params) && params[:commit] == 'Apply Changes'
       redirect_to event_application_path(@event.id, @application.id),
       notice: "You have successfully updated your application for #{@event.name}."
-    elsif @application.update(application_params) && params[:commit] == 'Save Changes'
-      redirect_to event_application_path(@event.id, @application.id),
-      notice: "You have successfully saved your changes to the draft."
+    elsif @application.update(application_params) && params[:commit] == 'Submit Application'
+      @application.update_attributes(submitted: true)
+      redirect_to user_applications_path(@application.applicant_id), notice: "You have successfully submitted an application for #{@event.name}."
+    elsif !@application.update(application_params) && params[:commit] == 'Submit Application'
+      render :show
+    elsif params[:commit] == 'Save Changes'
+      @application.skip_validation = true
+      if @application.update(application_params)
+        redirect_to event_application_path(@event.id, @application.id),
+        notice: "You have successfully saved your changes to the draft."
+      end
     else
       render :edit
     end
@@ -57,11 +65,6 @@ class ApplicationsController < ApplicationController
         render :new
       end
     end
-  end
-
-  def submit
-    @application.update_attributes(submitted: true)
-    redirect_to user_applications_path(@application.applicant_id), notice: "You have successfully submitted an application for #{@event.name}."
   end
 
   def approve

--- a/app/controllers/applications_controller.rb
+++ b/app/controllers/applications_controller.rb
@@ -48,8 +48,11 @@ class ApplicationsController < ApplicationController
         ApplicantMailer.application_received(@application).deliver_later
         current_user ? (path = event_application_path(@event.id, @application.id)) : (path = @event)
         redirect_to path, notice: "You have successfully applied for #{@event.name}."
-      elsif @application.save && params[:commit] == 'Save as a Draft'
-        redirect_to event_application_path(@event.id, @application.id), notice: "You have successfully saved an application draft for #{@event.name}."
+      elsif params[:commit] == 'Save as a Draft'
+        @application.skip_validation = true
+        if @application.save
+          redirect_to event_application_path(@event.id, @application.id), notice: "You have successfully saved an application draft for #{@event.name}."
+        end
       else
         render :new
       end
@@ -57,7 +60,6 @@ class ApplicationsController < ApplicationController
   end
 
   def submit
-    @application.skip_validation = true
     @application.update_attributes(submitted: true)
     redirect_to user_applications_path(@application.applicant_id), notice: "You have successfully submitted an application for #{@event.name}."
   end

--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -1,8 +1,8 @@
 class Application < ApplicationRecord
   belongs_to :event
   belongs_to :user
-  validates :name, :attendee_info_1, :attendee_info_2, presence: true
-  validates :email, presence: true, confirmation: true, format: { with: /.+@.+\..+/ }
+  validates :name, :attendee_info_1, :attendee_info_2, presence: true, unless: :skip_validation
+  validates :email, presence: true, confirmation: true, format: { with: /.+@.+\..+/ }, unless: :skip_validation
   validates :email_confirmation, presence: true, unless: :skip_validation
   validates :terms_and_conditions, acceptance: true, allow_nil: false, unless: :skip_validation
 

--- a/app/views/applications/_form.html.erb
+++ b/app/views/applications/_form.html.erb
@@ -46,7 +46,7 @@
     <div class="form_field--check">
       <%= label_tag do %>
       <%= f.check_box :terms_and_conditions %>
-      <span class="check-label">I agree with the following Terms and Conditions</span>
+      <span class="check-label">I agree with the following Terms and Conditions*</span>
       <% end %>
       <p id="terms-and-conditions">
         This diversity program is aimed to help underrepresented groups in tech to attend and lowering the barriers for them. This includes but isn’t limited to: women, people of color, LGBTQIA+ people, and disabled people. Your privacy, details and answers will only be shared with the organizers of <%= @event.name %>. We will not share any data with those who sponsor these tickets. This application is for one conference ticket only. The ticket includes

--- a/app/views/applications/edit.html.erb
+++ b/app/views/applications/edit.html.erb
@@ -37,8 +37,8 @@
 
     <div class="form_field--check">
       <%= label_tag do %>
-      <%= f.check_box :terms_and_conditions %>
-      <span class="check-label">I agree with the following Terms and Conditions</span>
+      <%= f.check_box :terms_and_conditions, checked: false %>
+      <span class="check-label">I agree with the following Terms and Conditions*</span>
       <% end %>
       <p id="terms-and-conditions">
         This diversity program is aimed to help underrepresented groups in tech to attend and lowering the barriers for them. This includes but isn’t limited to: women, people of color, LGBTQIA+ people, and disabled people. Your privacy, details and answers will only be shared with the organizers of <%= @event.name %>. We will not share any data with those who sponsor these tickets. This application is for one conference ticket only. The ticket includes

--- a/app/views/applications/show.html.erb
+++ b/app/views/applications/show.html.erb
@@ -46,7 +46,7 @@
 
 <% if @application.event.open? %>
   <% if !@application.submitted %>
-    <%= form_for @application, url: event_application_path(@event.id, @application.id), builder: ::FormBuilder do |f| %>
+    <%= form_for @application, url: submit_event_application_path(@event.id, @application.id), builder: ::FormBuilder do |f| %>
 
       <% if @application.errors.any? %>
         <div class="error">

--- a/app/views/applications/show.html.erb
+++ b/app/views/applications/show.html.erb
@@ -36,19 +36,69 @@
     <strong>Email</strong>
     <%= @application.email %>
   </p>
+
+  <% if @application.visa_needed %>
+    <p class="detail-pair">
+      <strong>I need a Visa.</strong>
+    </p>
+  <% end %>
 </section>
 
 <% if @application.event.open? %>
-  <div>
+  <% if !@application.submitted %>
+    <%= form_for @application, url: event_application_path(@event.id, @application.id), builder: ::FormBuilder do |f| %>
+
+      <% if @application.errors.any? %>
+        <div class="error">
+          <p><%= pluralize(@application.errors.count, "error") %> stopped this application from being saved:</p>
+          <ul>
+            <% @application.errors.messages.each do |field, messages| %>
+              <li><%= @application.class.human_attribute_name(field) %> <%= join_messages(messages) %></li>
+            <% end %>
+          </ul>
+        </div>
+      <% end %>
+
+      <section class="box">
+        <%= f.form_field :text_field, :email_confirmation, 'Email Confirmation' %>
+        <div class="form_field--check">
+          <%= label_tag do %>
+          <%= f.check_box :terms_and_conditions, checked: false %>
+          <span class="check-label">I agree with the following Terms and Conditions*</span>
+          <% end %>
+          <p id="terms-and-conditions">
+            This diversity program is aimed to help underrepresented groups in tech to attend and lowering the barriers for them. This includes but isn’t limited to: women, people of color, LGBTQIA+ people, and disabled people. Your privacy, details and answers will only be shared with the organizers of <%= @event.name %>. We will not share any data with those who sponsor these tickets. This application is for one conference ticket only. The ticket includes
+          </p>
+          <ul>
+            <% if @event.ticket_funded? %>
+              <li>admission to the conference,</li>
+            <% end %>
+            <% if @event.travel_funded? %>
+              <li>travel costs,</li>
+            <% end %>
+            <% if @event.accommodation_funded? %>
+              <li>accommodation,</li>
+            <% end %>
+            <li>catering for the day of the conference,</li>
+            <li>and admission to the parties organised for the conference attendees, speakers, and staff.</li>
+          </ul>
+          <% if @event.travel_funded? %>
+            <p>If you applied for a travel grant and were accepted, you will get reimbursed for your costs either up to 300 € (EU) or up to 900 € (non-EU). Note: You will only get reimbursed when the organizers of the conference can confirm that you actually attended the conference. They will take note of your name at the registration desk.</p>
+          <% end %>
+          <p>All attendees, speakers, sponsors and staff at <%= @event.name %> are required to agree with the <%= link_to 'Code of Conduct', "#{@event.code_of_conduct}" %> of the event. Organizers will enforce this code throughout the event.</p>
+        </div>
+      </section>
+      <div>
+        <%= f.submit("Submit Application", class: "btn btn-save") %>
+    <% end %>
+  <% else %>
+    <div>
+  <% end %>
     <%= link_to 'Edit', edit_event_application_path(@event.id, @application.id),
         class: "btn btn-edit" %>
     <%= link_to 'Delete', event_application_path(@event.id, @application.id),
         class: "btn btn-delete",  method: :delete,
         data: { confirm: "Are you sure you want to delete this application?" } %>
-    <% if !@application.submitted %>
-      <%= link_to 'Submit Application', submit_event_application_path(@event.id, @application.id),
-          class: "btn btn-save", method: :post %>
-    <% end %>
   </div>
 <% elsif current_user.admin? || @application.submitted == false %>
   <div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,6 +27,7 @@ Rails.application.routes.draw do
   get '/past_events', to: 'events#index_past', as: :past_events
   get '/admin', to: 'admin_events#index'
   delete '/events/:event_id/application/:id', to: 'applications#admin_destroy', as: :admin_event_application
+  patch '/events/:event_id/application/:id/submit', to: 'applications#submit', as: :submit_event_application
   get '/events/:id/admin', to: 'admin_events#show', as: :event_admin
   post '/events/preview', to: 'events#preview', as: :event_preview
   get '/about', to: 'home#about', as: :about

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,7 +28,6 @@ Rails.application.routes.draw do
   get '/admin', to: 'admin_events#index'
   delete '/events/:event_id/application/:id', to: 'applications#admin_destroy', as: :admin_event_application
   get '/events/:id/admin', to: 'admin_events#show', as: :event_admin
-  post '/events/:event_id/applications/:id', to: 'applications#submit', as: :submit_event_application
   post '/events/preview', to: 'events#preview', as: :event_preview
   get '/about', to: 'home#about', as: :about
   get '/faq', to: 'home#faq', as: :faq

--- a/test/integration/application_draft_page_test.rb
+++ b/test/integration/application_draft_page_test.rb
@@ -8,6 +8,8 @@ feature 'Application draft' do
     @draft = make_draft(
                   @event,
                   applicant_id: @user.id,
+                  email: @user.email,
+                  email_confirmation: @user.email,
                   attendee_info_1: 'I would like to learn Ruby',
                   attendee_info_2: 'I can not afford the ticket'
                 )
@@ -27,7 +29,7 @@ feature 'Application draft' do
 
     visit event_application_path(@event.id, @draft.id)
 
-    assert page.has_content?('Submit Application')
+    assert page.has_button?('Submit Application')
   end
 
   test 'does not show link to Submit if user is an applicant and event-deadline has passed' do
@@ -44,7 +46,13 @@ feature 'Application draft' do
 
     visit event_application_path(@event.id, @draft.id)
 
-    click_link('Submit Application')
+    @draft.update_attributes(email_confirmation: '', terms_and_conditions: false)
+
+    fill_in 'Email Confirmation', with: @user.email
+
+    check('I agree with the following Terms and Conditions*')
+
+    click_button('Submit Application')
 
     @draft.reload
 

--- a/test/integration/application_draft_page_test.rb
+++ b/test/integration/application_draft_page_test.rb
@@ -42,16 +42,13 @@ feature 'Application draft' do
   end
 
   test 'sets the status of the application to submitted after clicking Submit' do
+    @draft.update_attributes(email_confirmation: '', terms_and_conditions: false)
     sign_in_as_user
 
     visit event_application_path(@event.id, @draft.id)
 
-    @draft.update_attributes(email_confirmation: '', terms_and_conditions: false)
-
     fill_in 'Email Confirmation', with: @user.email
-
     check('I agree with the following Terms and Conditions*')
-
     click_button('Submit Application')
 
     @draft.reload

--- a/test/integration/application_edit_page_test.rb
+++ b/test/integration/application_edit_page_test.rb
@@ -67,4 +67,29 @@ feature 'Application Edit' do
 
     assert page.has_content?("You cannot edit your application as the #{@event.name} deadline has already passed")
   end
+
+  test 'shows correct flash message after saving changes to the draft' do
+    sign_in_as_user
+
+    visit edit_event_application_path(@event2.id, @draft.id)
+
+    fill_in 'application[attendee_info_1]', with: "I made some changes."
+    click_button('Save Changes')
+
+    assert page.has_content?("You have successfully saved your changes to the draft.")
+  end
+
+  test 'shows correct flash message after submitting changes to an application' do
+    sign_in_as_user
+
+    visit edit_event_application_path(@event.id, @application.id)
+
+    fill_in 'application[attendee_info_1]', with: "I made some changes."
+    fill_in 'application[email_confirmation]', with: @user.email
+    check 'application[terms_and_conditions]'
+
+    click_button('Apply Changes')
+
+    assert page.has_content?("You have successfully updated your application for #{@event.name}.")
+  end
 end

--- a/test/integration/new_application_test.rb
+++ b/test/integration/new_application_test.rb
@@ -143,4 +143,18 @@ feature 'New Application' do
 
     assert_equal current_path, event_application_path(@event.id, draft.id)
   end
+
+  test 'shows correct flash message for creating a draft' do
+    sign_in_as_user
+
+    visit event_path(@event.id)
+
+    click_button "Apply"
+
+    assert page.has_button?("Save as a Draft")
+
+    click_button "Save as a Draft"
+
+    assert page.has_content?("You have successfully saved an application draft for #{@event.name}.")
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -109,7 +109,7 @@ class ActiveSupport::TestCase
       name: 'Joe',
       email: 'joe@test.com',
       email_confirmation: 'joe@test.com',
-      terms_and_conditions: '1',
+      terms_and_conditions: true,
       event: event,
       submitted: true
     }
@@ -124,7 +124,7 @@ class ActiveSupport::TestCase
       name: 'Joe',
       email: 'joe@test.com',
       email_confirmation: 'joe@test.com',
-      terms_and_conditions: '1',
+      terms_and_conditions: true,
       event: event,
       submitted: false
     }


### PR DESCRIPTION
This PR lets applicants save and edit drafts of their applications without requiring accepted terms and conditions as well as filled out fields. When an applicant submits an application or edits an already submitted application they have to manually check the box for terms and conditions-acceptance and enter their email-confirmation first and everytime they submit changes. This ensures, that there are no submitted applications without accepted Terms and Conditions and verified email-confirmation. At the same time users don't have to finish the entire application if they just want to save a draft.