### PR TITLE
Application approval/reject/revert buttons

### DIFF
--- a/app/assets/stylesheets/icons.sass
+++ b/app/assets/stylesheets/icons.sass
@@ -31,10 +31,8 @@
   background-size: 20px
   background-position: 3px 1px
 
-.approve-application-icon, .reject-application-icon
+.approve-application, .reject-application, .revert-application
   font-size: 23px
-  position: relative
-  top: 4px
   padding: 0 30px 0 0
 
 .approve-application-icon
@@ -42,3 +40,11 @@
 
 .reject-application-icon
   color: $red
+
+.icon-delete-application
+    @extend %icon
+    background-image: image-url("icon-delete.svg")
+    background-size: 18px 21px
+    background-position: 3px 1px
+    position: relative
+    top: -10px

--- a/app/assets/stylesheets/tooltip.sass
+++ b/app/assets/stylesheets/tooltip.sass
@@ -10,7 +10,7 @@
     transform: translate(-30%)
     font-size: 11px
     font-weight: 400
-    background: $blue
+    background: $grey-dark
     color: white
     width: 5em
     padding: 0.1em 0.3em
@@ -27,13 +27,13 @@
     left: 0
     right: 0
     transform: rotate(45deg)
-    background-color: $blue
+    background-color: $grey-dark
     display: none
   &:hover
     &:after,
     &:before
       display: block
-      
+
 .tooltip-large
   position: relative
   text-decoration: none
@@ -46,7 +46,7 @@
     transform: translate(-30%)
     font-size: 11px
     font-weight: 400
-    background: $blue
+    background: $grey-dark
     color: white
     width: 7em
     padding: 0.1em 0.3em
@@ -63,12 +63,9 @@
     left: 0
     right: 0
     transform: rotate(45deg)
-    background-color: $blue
+    background-color: $grey-dark
     display: none
   &:hover
     &:after,
     &:before
       display: block
-      
-
-

--- a/app/controllers/applications_controller.rb
+++ b/app/controllers/applications_controller.rb
@@ -3,7 +3,7 @@ class ApplicationsController < ApplicationController
   before_action :get_event
   before_action :get_application, except: [:new, :create]
   before_action :ensure_correct_user, only: [:show, :edit]
-  before_action :skip_validation, only: [:save_draft, :approve, :reject, :undo]
+  before_action :skip_validation, only: [:save_draft, :approve, :reject, :revert]
   skip_before_action :require_login, only: [:new, :create]
 
   def show
@@ -46,7 +46,7 @@ class ApplicationsController < ApplicationController
       message = "You have successfully saved an application draft for #{@event.name}."
     end
     if @application.save
-      redirect_to event_application_path(@event.id, @application.id), notice: message 
+      redirect_to event_application_path(@event.id, @application.id), notice: message
     end
   end
 
@@ -88,7 +88,7 @@ class ApplicationsController < ApplicationController
   end
 
 
-  def undo
+  def revert
     @application.update_attributes(status: "pending")
     redirect_to admin_event_path(@application.event_id), flash: { :info => "#{@application.name}'s application has been changed to pending" }
   end

--- a/app/controllers/applications_controller.rb
+++ b/app/controllers/applications_controller.rb
@@ -75,7 +75,7 @@ class ApplicationsController < ApplicationController
     redirect_to admin_event_path(@application.event_id), flash: { :info => "#{@application.name}'s application has been rejected" }
   end
 
-  def undo
+  def revert
     @application.skip_validation = true
     @application.update_attributes(status: "pending")
     redirect_to admin_event_path(@application.event_id), flash: { :info => "#{@application.name}'s application has been changed to pending" }

--- a/app/views/admin_events/show.html.erb
+++ b/app/views/admin_events/show.html.erb
@@ -28,10 +28,10 @@
                 </p>
                 <p>
                   <% if (application.status == "approved") || (application.status == "rejected") %>
-                    <%= link_to undo_event_application_path(application.event_id, application.id),
+                    <%= link_to revert_event_application_path(application.event_id, application.id),
                         method: :post, class: "icon tooltip",
-                        title: 'undo' do %>
-                        Undo
+                        title: 'revert' do %>
+                        Revert
                       <% end %>
                   <% else %>
                     <%= link_to approve_event_application_path(application.event_id, application.id),

--- a/app/views/admin_events/show.html.erb
+++ b/app/views/admin_events/show.html.erb
@@ -29,27 +29,27 @@
                 <p>
                   <% if (application.status == "approved") || (application.status == "rejected") %>
                     <%= link_to revert_event_application_path(application.event_id, application.id),
-                        method: :post, class: "icon tooltip",
+                        method: :post, class: "btn btn-edit revert-application",
                         title: 'revert' do %>
                         Revert
                       <% end %>
                   <% else %>
                     <%= link_to approve_event_application_path(application.event_id, application.id),
-                        method: :post, class: "icon tooltip",
+                        method: :post, class: "btn btn-save approve-application",
                         title: 'approve' do %>
-                      <span class="approve-application-icon" aria-label="approve icon">&#x2714;</span>
+                      Approve
                     <% end %>
 
                     <%= link_to reject_event_application_path(application.event_id, application.id),
-                        method: :post, class: "icon tooltip",
+                        method: :post, class: "btn btn-external reject-application",
                         title: 'reject' do %>
-                      <span class="reject-application-icon" aria-label="reject icon">&#x2718;</span>
+                      Reject
                     <% end %>
                   <% end %>
 
                   <%= link_to admin_event_application_path(application.id, application.event_id), method: :delete,
                       data: { confirm: "Are you sure?"}, class: "icon tooltip", title: "delete" do %>
-                    <span class="icon-delete" aria-label="trashcan icon"></span>
+                    <span class="icon-delete-application" aria-label="trashcan icon"></span>
                   <% end %>
                 </p>
               </li>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -35,7 +35,7 @@ Rails.application.routes.draw do
   get '/users/:id/applications', to: 'users#applications', as: :user_applications
   post '/events/:event_id/applications:id/approve', to: 'applications#approve', as: :approve_event_application
   post '/events/:event_id/applications:id/reject', to: 'applications#reject', as: :reject_event_application
-  post '/events/:event_id/applications:id/undo', to: 'applications#undo', as: :undo_event_application
+  post '/events/:event_id/applications:id/revert', to: 'applications#revert', as: :revert_event_application
 
   root 'home#home'
 end

--- a/db/migrate/20180531090824_change_column_default_of_status_for_applications.rb
+++ b/db/migrate/20180531090824_change_column_default_of_status_for_applications.rb
@@ -1,0 +1,5 @@
+class ChangeColumnDefaultOfStatusForApplications < ActiveRecord::Migration[5.2]
+  def change
+    change_column_default :applications, :status, "pending"
+  end
+end

--- a/db/migrate/20180531091054_add_terms_and_conditions_to_applications.rb
+++ b/db/migrate/20180531091054_add_terms_and_conditions_to_applications.rb
@@ -1,5 +1,5 @@
 class AddTermsAndConditionsToApplications < ActiveRecord::Migration[5.2]
   def change
-    add_column :applications, :terms_and_conditions, :boolean, default: false
+    add_column :applications, :terms_and_conditions, :boolean, default: false, null: false
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_05_24_154828) do
+ActiveRecord::Schema.define(version: 2018_05_31_091054) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -27,13 +27,11 @@ ActiveRecord::Schema.define(version: 2018_05_24_154828) do
     t.boolean "travel_needed", default: false, null: false
     t.boolean "accommodation_needed", default: false, null: false
     t.boolean "visa_needed", default: false, null: false
-    t.boolean "terms_and_conditions", default: false
     t.integer "applicant_id"
     t.boolean "submitted", default: false, null: false
-    t.string "status"
-    t.boolean "terms_and_conditions", default: false
+    t.string "status", default: "pending"
+    t.boolean "terms_and_conditions", default: false, null: false
     t.index ["event_id"], name: "index_applications_on_event_id"
-    t.boolean "terms_and_conditions", default: false
   end
 
   create_table "categories", force: :cascade do |t|

--- a/test/integration/admin_event_details_test.rb
+++ b/test/integration/admin_event_details_test.rb
@@ -118,8 +118,8 @@ feature 'Admin Event Details' do
 
     assert page.has_content?("Approved Applications (1)")
     assert page.has_content?("Pending Applications (2)")
-
-    click_link('Revert')
+    
+    page.first('a.btn.btn-edit.revert-application').click
 
     assert page.has_content?("Lara's application has been changed to pending")
 

--- a/test/integration/admin_event_details_test.rb
+++ b/test/integration/admin_event_details_test.rb
@@ -111,7 +111,7 @@ feature 'Admin Event Details' do
     assert page.has_content?("Rejected Applications (1)")
   end
 
-  test 'changes application status back to pending after clicking on undo link' do
+  test 'changes application status back to pending after clicking on revert link' do
     sign_in_as_admin
 
     visit admin_event_path(@event.id)
@@ -119,7 +119,7 @@ feature 'Admin Event Details' do
     assert page.has_content?("Approved Applications (1)")
     assert page.has_content?("Pending Applications (2)")
 
-    click_link('Undo')
+    click_link('Revert')
 
     assert page.has_content?("Lara's application has been changed to pending")
 

--- a/test/integration/admin_event_details_test.rb
+++ b/test/integration/admin_event_details_test.rb
@@ -51,8 +51,8 @@ feature 'Admin Event Details' do
 
     visit admin_event_path(@event.id)
 
-    page.assert_selector('.approve-application-icon')
-    page.assert_selector('.reject-application-icon')
+    page.assert_selector('.approve-application')
+    page.assert_selector('.reject-application')
   end
 
   test 'shows a list of pending applications' do

--- a/test/integration/admin_event_details_test.rb
+++ b/test/integration/admin_event_details_test.rb
@@ -87,7 +87,7 @@ feature 'Admin Event Details' do
     assert page.has_content?("Approved Applications (1)")
     assert page.has_content?("Pending Applications (2)")
 
-    page.first('a.icon.tooltip').click
+    page.first('a.btn.btn-save.approve-application').click
 
     assert page.has_content?("Peter's application has been approved!")
 
@@ -103,7 +103,7 @@ feature 'Admin Event Details' do
     assert page.has_content?("Pending Applications (2)")
     assert page.has_content?("Rejected Applications (0)")
 
-    page.all('a.icon.tooltip')[1].click
+    page.first('a.btn.btn-external.reject-application').click
 
     assert page.has_content?("Peter's application has been rejected")
 


### PR DESCRIPTION
This PR makes some layout changes in the admin_event_details view:
- changes approve and reject icons as well as the "undo" link  to *buttons*
- renames "undo" to *"revert"* for a better understanding of what the actions will do
- changes the tooltip hover background color from blue to *dark-grey* for better readability (whole app)