### PR TITLE
Delete & update user account

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -36,7 +36,6 @@ class UsersController < Clearance::UsersController
         end
         redirect_to edit_user_path(@user), notice: "You have successfully updated your user data."
       else
-        pp "RENDER EDIT"
       render :edit
       end
     else

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,5 +1,5 @@
 class UsersController < Clearance::UsersController
-  before_action :ensure_correct_user, only: [:show, :edit, :update, :applications]
+  before_action :ensure_correct_user, only: [:show, :edit, :update, :destroy, :applications]
 
   def show
     @categorized_user_events = {
@@ -30,6 +30,16 @@ class UsersController < Clearance::UsersController
       flash.now[:error] = "Password is a mandatory field"
       render :edit
     else
+      render :edit
+    end
+  end
+
+  def destroy
+    if @user.destroy
+      flash[:alert] = "Your Account has been deleted successfully."
+      redirect_to root_path
+    else
+      flash[:error] = "Something went wrong. Please try again."
       render :edit
     end
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,5 +1,5 @@
 class UsersController < Clearance::UsersController
-  before_action :ensure_correct_user, only: [:show, :edit, :update, :destroy, :applications]
+  before_action :ensure_correct_user, only: [:show, :edit, :update, :destroy, :applications, :delete_account]
 
   def show
     @categorized_user_events = {
@@ -24,13 +24,24 @@ class UsersController < Clearance::UsersController
   end
 
   def update
-    if @user.update(user_params)
-      redirect_to edit_user_path(@user), notice: "You have successfully updated your user data."
-    elsif user_params[:password] === ''
-      flash.now[:error] = "Password is a mandatory field"
+    if user_params[:password] === ''
+      flash[:error] = "Password is a mandatory field"
+      redirect_to edit_user_path(@user)
+    elsif @user.authenticated?(params[:user][:password])
+      if @user.update(user_params) && params[:commit] == "Delete Account"
+        redirect_to delete_account_path(@user)
+      elsif @user.update(user_params)
+        if user_params[:new_password] != ''
+          @user.update_attributes(password: user_params[:new_password])
+        end
+        redirect_to edit_user_path(@user), notice: "You have successfully updated your user data."
+      else
+        pp "RENDER EDIT"
       render :edit
+      end
     else
-      render :edit
+      flash[:error] = "Incorrect password"
+      redirect_to edit_user_path(@user)
     end
   end
 
@@ -39,8 +50,13 @@ class UsersController < Clearance::UsersController
       flash[:alert] = "Your Account has been deleted successfully."
       redirect_to root_path
     else
-      flash[:error] = "Something went wrong. Please try again."
       render :edit
+    end
+  end
+
+  def delete_account
+    if request.env["HTTP_REFERER"] != edit_user_url(@user)
+      redirect_to root_path, alert: "We're sorry. You don't have permission to access this page."
     end
   end
 
@@ -60,7 +76,7 @@ class UsersController < Clearance::UsersController
     end
 
     def user_params
-      params.require(:user).permit(:name, :email, :password)
+      params.require(:user).permit(:name, :email, :password, :new_password)
     end
 
     def user_from_params

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -11,4 +11,8 @@ class User < ApplicationRecord
   def self.created_last_30_days
     where('created_at > ?', 31.days.ago)
   end
+
+  def validate_password
+    validates :password
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,15 +4,13 @@ class User < ApplicationRecord
   has_many :events, foreign_key: :organizer_id, dependent: :nullify
   has_many :applications, foreign_key: :applicant_id
 
+  attr_accessor :new_password
+
   def self.admin
   	where(admin: true)
   end
 
   def self.created_last_30_days
     where('created_at > ?', 31.days.ago)
-  end
-
-  def validate_password
-    validates :password
   end
 end

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -2,4 +2,6 @@
 
 <%= form.form_field :email_field, :email, "Email" %>
 
-<%= form.form_field :password_field, :password, "Password" %>
+<%= form.form_field :password_field, :new_password, "New Password" %>
+
+<%= form.form_field :password_field, :password, "Old Password" %>

--- a/app/views/users/delete_account.html.erb
+++ b/app/views/users/delete_account.html.erb
@@ -1,0 +1,42 @@
+<h1><%= t(".title") %></h1>
+
+<section class="box">
+  <h3>Deleting your account is irreversible.</h3>
+  <p>
+    We would be sad to see you go and don't want you to miss out on the benefits of
+    being a signed up user.
+    <br>
+    If you proceed with the account deletion the following things will happen:
+    <li>
+      Your submitted applications will still be valid. <strong>However:</strong>
+    </li>
+    <li>
+      You will not be able to visit or manage your current applications or drafts
+      anymore.
+    </li>
+    <li>
+      New applications can only be submitted as a guest, unless you sign up for a
+      new user account again.
+    </li>
+    <li>
+      If you sign up again, you will not be able to retreive your "old" data.
+    </li>
+    <li>
+      As a guest you will be missing out on the opportunity to receive updates
+      about our latest conferences or other interesting events for you.
+    </li>
+  </p>
+  <p>
+    <strong>Please note</strong> that you can manage your email-preferences
+    in your account settings. You don't have to receive our newsletters if you
+    don't want to.
+  </p>
+</section>
+
+<h3>Are you sure you want to delete your user account?</h3>
+
+<div class="submit-field">
+  <%= link_to 'No, go back!', edit_user_path(@user), class: "btn btn-save" %>
+  <%= link_to 'Yes, delete account!', destroy_user_path(@user), class: "btn btn-delete",
+      method: :delete %>
+</div>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -5,6 +5,10 @@
 
   <div class="submit-field">
     <%= form.submit(class: "btn btn-save") %>
+    <%= link_to 'Delete Account', user_path(@user.id),
+        class: "btn btn-delete",  method: :delete,
+        data: { confirm: "With this your data will be deleted from the system irrevocably.
+          Are you sure you want to delete your account?" } %>
   </div>
 
 <% end %>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -1,14 +1,9 @@
 <h2><%= t(".title") %></h2>
-
 <%= form_for @user, builder: ::FormBuilder do |form| %>
   <%= render partial: '/users/form', object: form %>
 
   <div class="submit-field">
     <%= form.submit(class: "btn btn-save") %>
-    <%= link_to 'Delete Account', user_path(@user.id),
-        class: "btn btn-delete",  method: :delete,
-        data: { confirm: "With this your data will be deleted from the system irrevocably.
-          Are you sure you want to delete your account?" } %>
+    <%= form.submit 'Delete Account', class: "btn btn-delete" %>
   </div>
-
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -51,3 +51,5 @@ en:
       title: "Your Applications"
       submitted: "Submitted"
       drafts: "Drafts"
+    delete_account:
+      title: "Are you sure?"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@ Rails.application.routes.draw do
   resources :passwords, controller: 'clearance/passwords', only: [:create, :new]
   resource :session, controller: 'sessions', only: [:create]
 
-  resources :users, controller: 'users', only: [:create, :show, :edit, :update]
+  resources :users, controller: 'users', only: [:create, :show, :edit, :update, :destroy]
   resources :users, controller: 'clearance/users', only: [:create] do
     resource :password,
       controller: 'clearance/passwords',

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,7 @@ Rails.application.routes.draw do
   resources :users, controller: 'clearance/users', only: [:create] do
     resource :password,
       controller: 'clearance/passwords',
-      only: [:create, :edit, :update]
+      only: [:create, :edit, :update, :destroy]
   end
 
   resources :events do
@@ -36,6 +36,8 @@ Rails.application.routes.draw do
   post '/events/:event_id/applications:id/approve', to: 'applications#approve', as: :approve_event_application
   post '/events/:event_id/applications:id/reject', to: 'applications#reject', as: :reject_event_application
   post '/events/:event_id/applications:id/undo', to: 'applications#undo', as: :undo_event_application
+  delete 'users/:id', to: 'users#destroy', as: :destroy_user
+  get 'users/:id/delete', to: 'users#delete_account', as: :delete_account
 
   root 'home#home'
 end

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -113,4 +113,21 @@ class UsersControllerTest < ActionController::TestCase
       assert categorized_user_events[:past].include?(past_event)
     end
   end
+
+  describe '#destroy' do
+    it 'deletes user from database' do
+      user1 = make_user(email: 'a@example.org')
+      user2 = make_user(email: 'b@example.org')
+
+      sign_in_as(user2)
+
+      assert_equal 'b@example.org', User.last.email
+
+      delete :destroy, params: { id: user2.id }
+
+      assert_redirected_to root_path
+      assert_equal "Your Account has been deleted successfully.", flash[:alert]
+      assert_equal 'a@example.org', User.last.email
+    end
+  end
 end

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -28,13 +28,14 @@ class UsersControllerTest < ActionController::TestCase
     end
 
     it 'allows user to edit their data' do
-      user = make_user(email: 'la@le.lu')
+      user = make_user(email: 'la@le.lu', password: '654321')
       sign_in_as(user)
 
       put :update, params: { id: user.id, user: { email: 'cool@email.add', password: '654321' } }
       user.reload
 
-      assert_equal user.email, 'cool@email.add'
+      assert_equal "You have successfully updated your user data.", flash[:notice]
+      assert_equal 'cool@email.add', user.email
       assert_redirected_to edit_user_path(user)
     end
 
@@ -45,8 +46,9 @@ class UsersControllerTest < ActionController::TestCase
       put :update, params: { id: user.id, user: { email: '' } }
       user.reload
 
-      assert_equal user.email, 'ta@da.aa'
-      assert_response :success
+      assert_nil flash[:notice]
+      assert_equal 'ta@da.aa', user.email
+      assert_redirected_to edit_user_path(user)
     end
   end
 

--- a/test/integration/user_delete_account_page_test.rb
+++ b/test/integration/user_delete_account_page_test.rb
@@ -1,0 +1,57 @@
+require 'test_helper'
+
+feature 'User Delete Account Page' do
+  def setup
+    @user = make_user
+  end
+
+  test 'that back- and delete-links are being shown correctly' do
+    sign_in_as_user
+
+    visit root_path
+
+    assert page.text.include?("#{@user.name}")
+
+    page.find("#dropdown-btn").click
+    click_link 'Account Settings'
+
+    page.fill_in 'user_password', with: @user.password
+    click_button 'Delete Account'
+
+    assert page.text.include?("Are you sure?")
+    assert page.has_link?('No, go back!')
+    assert page.has_link?('Yes, delete account!')
+  end
+
+  test 'that admins can not access the delete account page of other users' do
+    admin = make_admin
+    sign_in_as_admin
+
+    visit delete_account_path(@user)
+
+    assert page.text.include?("We're sorry. You don't have permission to access this page.")
+  end
+
+  test 'that no user can access the delete account page of other users' do
+    user2 = make_user(email: 'b@user.com')
+
+    visit '/'
+    click_link 'Sign in'
+
+    fill_in 'Email', with: 'b@user.com'
+    fill_in 'Password', with: 'awesome_password'
+    click_button 'Sign in'
+
+    visit delete_account_path(@user)
+
+    assert page.text.include?("We're sorry. You don't have permission to access this page.")
+  end
+
+  test 'that users can only access the delete account page via "Delete Account"-Button on their settings page' do
+    sign_in_as_user
+
+    visit delete_account_path(@user)
+
+    assert page.text.include?("We're sorry. You don't have permission to access this page.")
+  end
+end

--- a/test/integration/user_settings_page_test.rb
+++ b/test/integration/user_settings_page_test.rb
@@ -43,11 +43,6 @@ feature 'User Settings Page' do
 
     click_button 'Delete Account'
     assert page.text.include?('Password is a mandatory field')
-
-    page.fill_in 'user_password', with: @user.password
-    click_button 'Delete Account'
-
-    assert page.text.include?("Are you sure?")
   end
 
   test 'that password validation works and Delete Account redirects to delete account page' do

--- a/test/integration/user_settings_page_test.rb
+++ b/test/integration/user_settings_page_test.rb
@@ -10,7 +10,10 @@ feature 'User Settings Page' do
 
     visit root_path
 
-    click_link 'Settings'
+    assert page.text.include?("#{@user.name}")
+
+    page.find("#dropdown-btn").click
+    click_link 'Account Settings'
 
     assert page.text.include?('Edit your credentials')
     page.must_have_selector("form input[name='user[name]']")
@@ -24,5 +27,42 @@ feature 'User Settings Page' do
     @user.reload
 
     assert_equal 'My Name', @user.name
+  end
+
+  test 'that password is required for Delete Account' do
+    sign_in_as_user
+
+    visit root_path
+
+    assert page.text.include?("#{@user.name}")
+
+    page.find("#dropdown-btn").click
+    click_link 'Account Settings'
+
+    assert page.has_button?('Delete Account')
+
+    click_button 'Delete Account'
+    assert page.text.include?('Password is a mandatory field')
+
+    page.fill_in 'user_password', with: @user.password
+    click_button 'Delete Account'
+
+    assert page.text.include?("Are you sure?")
+  end
+
+  test 'that password validation works and Delete Account redirects to delete account page' do
+    sign_in_as_user
+
+    visit root_path
+
+    assert page.text.include?("#{@user.name}")
+
+    page.find("#dropdown-btn").click
+    click_link 'Account Settings'
+
+    page.fill_in 'user_password', with: @user.password
+    click_button 'Delete Account'
+
+    assert page.text.include?("Are you sure?")
   end
 end


### PR DESCRIPTION
This PR lets users delete their own account and update their data:
- includes password validation for all changes that happen on the edit account settings page
- lets user change their name, email and password
- adds a "delete account" button that redirects to a new delete-account-page
- delete-account-page:
* includes final confirmation buttons ("Yes, delete account" or "No, go back") 
* describes what happens upon account deletion and informs about consequences
* requires password validation and is only accessible via the edit account settings page
* can not be accessed by other users or admins
