### PR TITLE
Sign in to apply

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -12,7 +12,7 @@ class SessionsController < Clearance::SessionsController
       sign_in(@user) do |status|
 
         if status.success?
-            redirect_to params[:referer]
+          redirect_to params[:referer]
         else
           flash.now[:alert] = status.failure_message
           render template: "sessions/new", status: :unauthorized

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -14,7 +14,11 @@ class UsersController < Clearance::UsersController
     @user = user_from_params
     if @user.save
       sign_in @user
-      redirect_to root_path
+      unless params[:referer].include?('continue_as_guest')
+        redirect_to root_path
+      else
+        redirect_to new_event_application_path(params[:event_id])
+      end
     else
       render template: "users/new"
     end

--- a/app/views/applications/continue_as_guest.html.erb
+++ b/app/views/applications/continue_as_guest.html.erb
@@ -1,0 +1,4 @@
+Continue as guest?
+<%= link_to 'Yes, continue as guest', new_event_application_path(@event.id), class: "btn btn-edit" %>
+<%= link_to 'Sign me in', sign_in_path, class: "btn btn-edit" %>
+<%= link_to 'Create an account', sign_up_path(@event.id), class: "btn btn-edit" %>

--- a/app/views/applications/continue_as_guest.html.erb
+++ b/app/views/applications/continue_as_guest.html.erb
@@ -1,4 +1,42 @@
-Continue as guest?
-<%= link_to 'Yes, continue as guest', new_event_application_path(@event.id), class: "btn btn-edit" %>
-<%= link_to 'Sign me in', sign_in_path, class: "btn btn-edit" %>
-<%= link_to 'Create an account', sign_up_path(@event.id), class: "btn btn-edit" %>
+<p class="breadcrumb"><%= link_to 'Home', root_path %> > <%= link_to 'Events', events_path %> > <%= link_to @event.name, event_path(@event) %> > Application for <%= @event.name %></p>
+
+<h2><%= t(".title") %></h2>
+<section class="box">
+  <h3>Benefits of having a user account</h3>
+  <p>
+    If you have a free user account with Diversity Tickets you can:
+    <ul>
+      <li>
+        review and manage all of your applications in your applications dashboard
+      </li>
+      <li>
+        save applications as a draft before submission
+      </li>
+      <li>
+        come back to your draft later to finish and submit it
+      </li>
+      <li>
+        come back to your submitted applications later to edit them or withdraw your application
+        in case you changed your mind or your situation has changed before the end of the application deadline
+      </li>
+      <li>
+        save personal data such as your name and email address that will be saved
+        for your future applications (you will still be able to individually adjust that information)
+      </li>
+      <li>
+        manage your personal information and email preferences in your account settings
+        and decide which information you would like to share and/or receive
+      </li>
+      <li>
+        choose to receive updates about our latest conferences or other interesting events for you
+      </li>
+    </ul>
+    <strong>
+      If you continue as a guest you will not be able to save or come back to your
+      application.
+    </strong>
+  </p>
+</section>
+<%= link_to 'Sign me in', sign_in_path, class: "btn btn-save" %>
+<%= link_to 'Create an account', sign_up_path(@event.id), class: "btn btn-save" %>
+<%= link_to 'Continue as guest', new_event_application_path(@event.id), class: "btn btn-edit" %>

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -3,3 +3,7 @@
 <%= form.form_field :email_field, :email, "Email" %>
 
 <%= form.form_field :password_field, :password, "Password" %>
+
+<%= hidden_field_tag :referer, request.env["HTTP_REFERER"] %>
+
+<%= hidden_field_tag :event_id, params[:format] %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -51,3 +51,6 @@ en:
       title: "Your Applications"
       submitted: "Submitted"
       drafts: "Drafts"
+  applications:
+    continue_as_guest:
+      title: "How would you like to apply?"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -37,6 +37,7 @@ Rails.application.routes.draw do
   post '/events/:event_id/applications:id/approve', to: 'applications#approve', as: :approve_event_application
   post '/events/:event_id/applications:id/reject', to: 'applications#reject', as: :reject_event_application
   post '/events/:event_id/applications:id/undo', to: 'applications#undo', as: :undo_event_application
+  get '/events/:event_id/continue_as_guest', to: 'applications#continue_as_guest', as: :continue_as_guest
 
   root 'home#home'
 end

--- a/test/controllers/applications_controller_test.rb
+++ b/test/controllers/applications_controller_test.rb
@@ -72,6 +72,8 @@ class ApplicationsControllerTest < ActionController::TestCase
 
     it 'adds a new application if the selection process is not run by organizer' do
       event = make_event
+      user = make_user
+      sign_in_as(user)
 
       get :new, params: { event_id: event.id }
 

--- a/test/integration/applications_continue_as_guest_page_test.rb
+++ b/test/integration/applications_continue_as_guest_page_test.rb
@@ -1,0 +1,62 @@
+require 'test_helper'
+
+feature 'Application Edit' do
+  def setup
+    @user = make_user
+    @event = make_event(name: 'The Event', approved: true)
+  end
+
+  test 'that buttons for "Continue as guest", "Sign me in" and "Create an account" are present' do
+    visit events_path
+
+    click_button('Apply')
+
+    assert_current_path continue_as_guest_path(@event.id)
+
+    assert page.has_link?("Continue as guest")
+    assert page.has_link?("Sign me in")
+    assert page.has_link?("Create an account")
+  end
+
+  test 'successful redirect to new application form after clicking "Continue as guest"' do
+    visit events_path
+
+    click_button('Apply')
+
+    click_link 'Continue as guest'
+
+    assert_current_path new_event_application_path(@event.id)
+  end
+
+  test 'successful redirect to new application form after clicking "Sign me in"' do
+    visit events_path
+
+    click_button('Apply')
+
+    click_link 'Sign me in'
+
+    assert_current_path sign_in_path
+
+    fill_in 'Email', with: 'awesome@example.org'
+    fill_in 'Password', with: 'awesome_password'
+    click_button 'Sign in'
+
+    assert_current_path new_event_application_path(@event.id)
+  end
+
+  test 'successful redirect to new application form after clicking "Create an account"' do
+    visit events_path
+
+    click_button('Apply')
+
+    click_link 'Create an account'
+
+    assert_current_path sign_up_path(@event.id)
+
+    fill_in 'Email', with: 'new@example.org'
+    fill_in 'Password', with: 'new_password'
+    click_button 'Sign up'
+
+    assert_current_path new_event_application_path(@event.id)
+  end
+end

--- a/test/integration/new_application_test.rb
+++ b/test/integration/new_application_test.rb
@@ -12,6 +12,8 @@ feature 'New Application' do
 
     click_button "Apply"
 
+    click_link "Continue as guest"
+
     page.fill_in 'application_name', with: @user.name
     page.fill_in 'application_email', with: @user.email
     page.fill_in 'application_email_confirmation', with: @user.email
@@ -100,10 +102,22 @@ feature 'New Application' do
     assert_not page.has_content?('Save as a Draft')
   end
 
-  test 'shows sign-in link to not logged in users to allow them to use their credentials for this application' do
+  test 'shows continue_as_guest? page to not logged in users' do
     visit event_path(@event.id)
 
     click_button "Apply"
+
+    assert page.has_content?('How would you like to apply?')
+  end
+
+  test 'shows sign-in link to not logged in users inside application to still allow to sign-in after continuing as guest' do
+    visit event_path(@event.id)
+
+    click_button "Apply"
+
+    assert page.has_content?('How would you like to apply?')
+
+    click_link "Continue as guest"
 
     assert page.has_content?('Would you like to Sign In to use your profile information and save this application?')
   end


### PR DESCRIPTION
This PR creates a new view for not logged in users that appears when they click to apply for an event.
It informs the user about the benefits of continuing as a logged in user and lets the user choose between three options:
- Sign me in
- Create an account
- Continue as guest
After each choice/sign_in/sign_up there will be an automatic redirect to the new application form for the previously selected event.

This is to make sure that not logged in users and visitors are aware of their options and to prevent them from 'overlooking' the optional sign-in link inside of the application form and potentially missing out on the opportunity to save their application.