### PR TITLE
New fields of preference for users

### DIFF
--- a/app/assets/stylesheets/form.scss
+++ b/app/assets/stylesheets/form.scss
@@ -169,13 +169,15 @@ input.has-dependent:checked + div.form_field {
 }
 
 .category-tags {
-  padding: 1em;
-  border: 1px solid $border-grey;
-  border-radius: 4px;
   margin-bottom: 1em;
   label {
     display: inline-block;
     margin-right: 5px;
     white-space: nowrap;
   }
+}
+.tags-border {
+  padding: 1em;
+  border: 1px solid $border-grey;
+  border-radius: 4px;
 }

--- a/app/controllers/admin_events_controller.rb
+++ b/app/controllers/admin_events_controller.rb
@@ -70,11 +70,7 @@ class AdminEventsController < ApplicationController
     end
 
     def inform_applicants_field_of_interest
-      users = []
-      @event.tags.each do |tag|
-        users << tag.taggings.pluck(:user_id).uniq
-      end
-      users.flatten.uniq.compact.each do |user|
+      @event.interested_users.where(tag_email_notifications: true).each do |user|
         UserNotificationsMailer.new_local_event(@event, user).deliver_later
       end
     end

--- a/app/controllers/admin_events_controller.rb
+++ b/app/controllers/admin_events_controller.rb
@@ -71,7 +71,7 @@ class AdminEventsController < ApplicationController
 
     def inform_applicants_field_of_interest
       @event.interested_users.where(tag_email_notifications: true).each do |user|
-        UserNotificationsMailer.new_local_event(@event, user).deliver_later
+        UserNotificationsMailer.new_field_specific_event(@event, user).deliver_later
       end
     end
 end

--- a/app/controllers/admin_events_controller.rb
+++ b/app/controllers/admin_events_controller.rb
@@ -1,7 +1,7 @@
 require "report_exporter"
 
 class AdminEventsController < ApplicationController
-  before_action :get_event, only: [:show, :approve, :edit, :update, :destroy]
+  before_action :get_event, except: [:index, :anual_events_report]
   before_action :require_admin
 
   def index
@@ -44,9 +44,8 @@ class AdminEventsController < ApplicationController
     @event.toggle(:approved)
     @event.save!
     if @event.approved?
-      User.where(country: @event.country).where(country_email_notifications: true).each do |user|
-        UserNotificationsMailer.new_local_event(@event, user).deliver_later
-      end
+      inform_applicants_country
+      inform_applicants_field_of_interest
       redirect_to admin_url, notice: "#{@event.name} has been approved!"
     else
       redirect_to admin_url, notice: "#{@event.name} has been unapproved!"
@@ -62,5 +61,21 @@ class AdminEventsController < ApplicationController
 
     def get_event
       @event = Event.find(params[:id])
+    end
+
+    def inform_applicants_country
+      User.where(country: @event.country).where(country_email_notifications: true).each do |user|
+        UserNotificationsMailer.new_local_event(@event, user).deliver_later
+      end
+    end
+
+    def inform_applicants_field_of_interest
+      users = []
+      @event.tags.each do |tag|
+        users << tag.taggings.pluck(:user_id).uniq
+      end
+      users.flatten.uniq.compact.each do |user|
+        UserNotificationsMailer.new_local_event(@event, user).deliver_later
+      end
     end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -79,7 +79,9 @@ class UsersController < Clearance::UsersController
     end
 
     def user_params
-      params.require(:user).permit(:name, :email, :password, :new_password, :country, :country_email_notifications)
+      params.require(:user).permit(:name, :email, :password, :new_password,
+        :country, :country_email_notifications, :tag_email_notifications,
+        { :tag_ids => [] }, tags_attributes: [:id, :name, :category_id])
     end
 
     def user_from_params

--- a/app/mailers/user_notifications_mailer.rb
+++ b/app/mailers/user_notifications_mailer.rb
@@ -4,4 +4,10 @@ class UserNotificationsMailer < ApplicationMailer
     @user = user
     mail(to: @user.email, subject: 'A new event in your country!')
   end
+
+  def new_field_specific_event(event, user)
+    @event = event
+    @user = user
+    mail(to: @user.email, subject: 'A new event of your interest!')
+  end
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -6,6 +6,8 @@ class Event < ApplicationRecord
   has_many :taggings
   has_many :tags, through: :taggings
   has_many :tweets
+  has_many :tag_taggings, through: :tags, source: 'taggings'
+  has_many :interested_users, -> { distinct }, through: :tag_taggings, source: 'user'
 
   validates :organizer_name, :description, :name, :website, :code_of_conduct, :city, :country, presence: true
   validates :start_date, :deadline, date: true, presence: true

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,6 +1,7 @@
 class Tag < ActiveRecord::Base
   has_many :taggings
   has_many :events, through: :taggings
+  has_many :users, through: :taggings
   belongs_to :category
 
   validates :name, :category_id, presence: true

--- a/app/models/tagging.rb
+++ b/app/models/tagging.rb
@@ -1,4 +1,5 @@
 class Tagging < ActiveRecord::Base
   belongs_to :tag
   belongs_to :event
+  belongs_to :user
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,6 +3,8 @@ class User < ApplicationRecord
 
   has_many :events, foreign_key: :organizer_id, dependent: :nullify
   has_many :applications, foreign_key: :applicant_id
+  has_many :taggings
+  has_many :tags, through: :taggings, foreign_key: :user_id
 
   attr_accessor :new_password
 

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -20,7 +20,7 @@
         <label>Tags</label>
 
         <% Category.all.each do |category| %>
-          <div class="category-tags">
+          <div class="category-tags tags-border">
             <p class="border"><%= category.name.capitalize %></p>
             <%= f.collection_check_boxes(:tag_ids, category.tags.order(:name), :id, :name) do |tag| %>
               <%= tag.label { tag.check_box + " " + tag.text } %>

--- a/app/views/user_notifications_mailer/new_field_specific_event.text.erb
+++ b/app/views/user_notifications_mailer/new_field_specific_event.text.erb
@@ -1,0 +1,9 @@
+Dear <%= @user.name %>,
+
+There is a new event of your interest! You can check it here: <%= event_url(@event.id) %>
+
+If you have any more questions, please read the FAQ (https://diversitytickets.org/faq). If you need more help, contact foundation@travis-ci.org.
+
+The Travis Foundation Team
+
+-

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -1,7 +1,7 @@
 <h1><%= t(".title") %></h1>
 <%= form_for @user, builder: ::FormBuilder do |form| %>
   <div class="two-columns">
-    <section class="tags box col-6">
+    <section class="box col-6">
     <%= form.form_field :text_field, :name, t('.name') %>
 
     <%= form.form_field :email_field, :email, t('.email') %>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -12,8 +12,19 @@
   <%= form.form_field :password_field, :password, "Password" %>
 
 <h2><%= t(".email-notifications") %></h2>
-
-  <%= form.check_box :country_email_notifications %> <%= t('.receive-emails-country') %>
+  <p><%= form.check_box :country_email_notifications %> <%= t('.receive-emails-country') %></p>
+  <p><%= form.check_box :tag_email_notifications %> <%= t('.receive-emails-tag') %><p>
+  <div class="tags">
+    <label>Fields of interest</label>
+    <div class="category-tags">
+    <% Category.all.each do |category| %>
+        <p class="border"><%= category.name.capitalize %></p>
+        <%= form.collection_check_boxes(:tag_ids, category.tags.order(:name), :id, :name) do |tag| %>
+          <%= tag.label { tag.check_box + " " + tag.text } %>
+        <% end %>
+      <% end %>
+    </div>
+  </div>
 
   <div class="submit-field">
     <%= form.submit(t(".save-changes"), class: "btn btn-save") %>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -7,18 +7,11 @@
   <%= form.label t('.country') %>
   <%= form.select :country, CS.countries.values%>
 
-  <%= form.form_field :password_field, :new_password, "New password" %>
-
-  <%= form.form_field :password_field, :password, "Password" %>
-
-<h2><%= t(".email-notifications") %></h2>
-  <p><%= form.check_box :country_email_notifications %> <%= t('.receive-emails-country') %></p>
-  <p><%= form.check_box :tag_email_notifications %> <%= t('.receive-emails-tag') %><p>
   <div class="tags">
-    <label>Fields of interest</label>
+    <h3>Fields of interest</h3>
     <div class="category-tags">
     <% Category.all.each do |category| %>
-        <p class="border"><%= category.name.capitalize %></p>
+        <p><%= category.name.capitalize %></p>
         <%= form.collection_check_boxes(:tag_ids, category.tags.order(:name), :id, :name) do |tag| %>
           <%= tag.label { tag.check_box + " " + tag.text } %>
         <% end %>
@@ -26,8 +19,16 @@
     </div>
   </div>
 
+<h3><%= t(".email-notifications") %></h3>
+  <p><%= form.check_box :country_email_notifications %> <%= t('.receive-emails-country') %></p>
+  <p><%= form.check_box :tag_email_notifications %> <%= t('.receive-emails-tag') %><p>
+
+  <%= form.form_field :password_field, :new_password, "New password" %>
+
+  <%= form.form_field :password_field, :password, "Password" %>
   <div class="submit-field">
     <%= form.submit(t(".save-changes"), class: "btn btn-save") %>
     <%= form.submit 'Delete account', class: "btn btn-delete" %>
   </div>
+
 <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -46,6 +46,7 @@ en:
       name: "Name"
       password: "Password"
       receive-emails-country: "Yes, I want to get email notifications about new events taking place in the country I am based"
+      receive-emails-tag: "Yes, I want to get email notifications about new events that match my fields of interest"
       save-changes: "Save changes"
       title: "Profile settings"
     events:
@@ -59,9 +60,7 @@ en:
       drafts: "Drafts"
     delete_account:
       title: "Are you sure?"
-      
+
   applications:
     continue_as_guest:
       title: "How would you like to apply?"
-
-

--- a/db/migrate/20180613114549_add_user_id_to_taggings.rb
+++ b/db/migrate/20180613114549_add_user_id_to_taggings.rb
@@ -1,0 +1,6 @@
+class AddUserIdToTaggings < ActiveRecord::Migration[5.2]
+  def change
+    add_column :taggings, :user_id, :integer
+    add_column :users, :tag_email_notifications, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_06_04_132133) do
+ActiveRecord::Schema.define(version: 2018_06_13_114549) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -31,6 +31,7 @@ ActiveRecord::Schema.define(version: 2018_06_04_132133) do
     t.boolean "submitted", default: false, null: false
     t.string "status", default: "pending"
     t.boolean "terms_and_conditions", default: false, null: false
+    t.boolean "deleted", default: false
     t.index ["event_id"], name: "index_applications_on_event_id"
   end
 
@@ -66,6 +67,7 @@ ActiveRecord::Schema.define(version: 2018_06_04_132133) do
     t.string "twitter_handle"
     t.string "state_province"
     t.integer "organizer_id"
+    t.boolean "deleted", default: false
     t.index ["organizer_id"], name: "index_events_on_organizer_id"
   end
 
@@ -74,6 +76,7 @@ ActiveRecord::Schema.define(version: 2018_06_04_132133) do
     t.bigint "tag_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "user_id"
     t.index ["event_id"], name: "index_taggings_on_event_id"
     t.index ["tag_id"], name: "index_taggings_on_tag_id"
   end
@@ -104,6 +107,7 @@ ActiveRecord::Schema.define(version: 2018_06_04_132133) do
     t.string "name"
     t.boolean "country_email_notifications", default: false
     t.string "country"
+    t.boolean "tag_email_notifications", default: false
     t.index ["email"], name: "index_users_on_email"
     t.index ["remember_token"], name: "index_users_on_remember_token"
   end

--- a/test/integration/user_settings_page_test.rb
+++ b/test/integration/user_settings_page_test.rb
@@ -16,7 +16,7 @@ feature 'User Settings Page' do
 
     click_link 'Account settings'
 
-    assert page.text.include?('Profile settings')
+    assert page.text.include?('Account settings')
     page.must_have_selector("form input[name='user[name]']")
     page.fill_in 'user_name', with: 'My Name'
     page.fill_in 'user_password', with: @user.password

--- a/test/mailers/user_notifications_mailer_test.rb
+++ b/test/mailers/user_notifications_mailer_test.rb
@@ -6,7 +6,7 @@ class UserNotificationsMailerTest < ActionMailer::TestCase
     @user = make_user
   end
 
-  test "submitted_event" do
+  test "new_local_event" do
     email = UserNotificationsMailer.new_local_event(@event, @user)
 
     assert_emails 1 do
@@ -16,6 +16,18 @@ class UserNotificationsMailerTest < ActionMailer::TestCase
     assert_equal ['info@diversitytickets.org'], email.from
     assert_equal [@user.email], email.to
     assert_equal 'A new event in your country!', email.subject
+  end
+
+  test "new_field_specific_event" do
+    email = UserNotificationsMailer.new_field_specific_event(@event, @user)
+
+    assert_emails 1 do
+      email.deliver_now
+    end
+
+    assert_equal ['info@diversitytickets.org'], email.from
+    assert_equal [@user.email], email.to
+    assert_equal 'A new event of your interest!', email.subject
   end
 
 end


### PR DESCRIPTION
This PR enables the user the possibility to select their favorite programming languages and speaking languages. If they select any of them, they can enable email notifications for this fields of interest, and anytime a new event of that field is been approved, DT will send them an email notifying them. 
