### PR TITLE
Sign up consistency + Delete account locales

### DIFF
--- a/app/views/users/delete_account.html.erb
+++ b/app/views/users/delete_account.html.erb
@@ -1,42 +1,19 @@
 <h1><%= t(".title") %></h1>
 
 <section class="box">
-  <h3>Deleting your account is irreversible.</h3>
-  <p>
-    We would be sad to see you go and don't want you to miss out on the benefits of
-    being a signed up user.
-    <br>
-    If you proceed with the account deletion the following things will happen:
-    <li>
-      Your submitted applications will still be valid. <strong>However:</strong>
-    </li>
-    <li>
-      You will not be able to visit or manage your current applications or drafts
-      anymore.
-    </li>
-    <li>
-      New applications can only be submitted as a guest, unless you sign up for a
-      new user account again.
-    </li>
-    <li>
-      If you sign up again, you will not be able to retreive your "old" data.
-    </li>
-    <li>
-      As a guest you will be missing out on the opportunity to receive updates
-      about our latest conferences or other interesting events for you.
-    </li>
+  <h3><%= t(".subtitle") %></h3>
+  <p> <%= t(".benefits-intro") %>
+    <br> <%= raw t('.list-of-benefits') %>
   </p>
   <p>
-    <strong>Please note</strong> that you can manage your email-preferences
-    in your account settings. You don't have to receive our newsletters if you
-    don't want to.
+    <%= raw t('.email-preferences') %>
   </p>
 </section>
 
-<h3>Are you sure you want to delete your user account?</h3>
+<h3><%= t(".benefits-intro") %></h3>
 
 <div class="submit-field">
-  <%= link_to 'No, go back!', edit_user_path(@user), class: "btn btn-save" %>
-  <%= link_to 'Yes, delete account!', destroy_user_path(@user), class: "btn btn-delete",
+  <%= link_to t(".no-delete-button"), edit_user_path(@user), class: "btn btn-save" %>
+  <%= link_to t(".delete-button"), destroy_user_path(@user), class: "btn btn-delete",
       method: :delete %>
 </div>

--- a/config/locales/clearance.en.yml
+++ b/config/locales/clearance.en.yml
@@ -31,7 +31,7 @@ en:
       session:
         submit: Sign in
       user:
-        create: Sign up
+        create: Create your account
   layouts:
     application:
       sign_in: Sign in
@@ -50,10 +50,10 @@ en:
   sessions:
     form:
       forgot_password: Forgot password?
-      sign_up: Sign up
+      sign_up: Create your account
     new:
       title: Sign in
   users:
     new:
       sign_in: Sign in
-      title: Sign up
+      title: Create your account

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -59,9 +59,22 @@ en:
       drafts: "Drafts"
     delete_account:
       title: "Are you sure?"
-      
+      subtitle: "Deleting your account is irreversible."
+      benefits-intro: "We would be sad to see you go and don't want you to miss out on the benefits of
+      being a signed up user."
+      list-of-benefits: "If you proceed with the account deletion the following things will happen:
+      <li> Your submitted applications will still be valid. <strong>However:</strong> </li>
+      <li> You will not be able to visit or manage your current applications or drafts anymore.</li>
+      <li> New applications can only be submitted as a guest, unless you sign up for a new user account again.</li>
+      <li> If you sign up again, you will not be able to retrieve your \"old\" data. </li>
+      <li> As a guest you will be missing out on the opportunity to receive updates about our latest conferences or other interesting events for you.</li>"
+      email-preferences: "<strong>Please note</strong> that you can manage your email preferences
+          in your account settings. You don't have to receive our newsletters if you
+          don't want to."
+      are-you-sure: "Are you sure you want to delete your user account?"
+      no-delete-button: "No, go back!"
+      delete-button: "Yes, delete account!"
+
   applications:
     continue_as_guest:
       title: "How would you like to apply?"
-
-

--- a/test/integration/applications_continue_as_guest_page_test.rb
+++ b/test/integration/applications_continue_as_guest_page_test.rb
@@ -54,7 +54,7 @@ feature 'Application Edit' do
     assert_current_path sign_up_path(@event.id)
     fill_in 'Email', with: 'new@example.org'
     fill_in 'Password', with: 'new_password'
-    click_button 'Sign up'
+    click_button 'Create your account'
 
     assert_current_path new_event_application_path(@event.id)
   end

--- a/test/integration/sign_in_test.rb
+++ b/test/integration/sign_in_test.rb
@@ -38,7 +38,7 @@ feature 'User Sign In' do
     assert page.has_content?("Create your account")
     click_link "Create your account"
 
-    assert page.has_content?("Sign up")
+    assert page.has_content?("Create your account")
   end
 
   test 'sign-up page shows link to sign in with a "Sign in here"-Button' do


### PR DESCRIPTION
This PR includes all the feedback provided by @alicetragedy after deploying to staging. Basically adds more consistency for the sign up - account creation and adds locales to the delete account warn so it's easier to translate. It also corrects typos from this warn.