### PR TITLE
Validate user before submitting changes and deleting account

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -30,11 +30,11 @@ class UsersController < Clearance::UsersController
   def update
     if user_params[:password] === ''
       @user.update(user_params)
-      flash[:error] = "Password is a mandatory field"
+      flash.now[:error] = "Password is a mandatory field"
       render :edit
     elsif @user.authenticated?(params[:user][:password])
       if @user.update(user_params) && params[:commit] == "Delete account"
-        redirect_to delete_account_path(@user)
+        delete_account(@user)
       elsif @user.update(user_params)
         if user_params[:new_password] != ''
           @user.update_attributes(password: user_params[:new_password])
@@ -58,10 +58,8 @@ class UsersController < Clearance::UsersController
     end
   end
 
-  def delete_account
-    if request.env["HTTP_REFERER"] != edit_user_url(@user)
-      redirect_to root_path, alert: "We're sorry. You don't have permission to access this page."
-    end
+  def delete_account(user)
+    render :delete_account
   end
 
   def applications

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -29,8 +29,9 @@ class UsersController < Clearance::UsersController
 
   def update
     if user_params[:password] === ''
+      @user.update(user_params)
       flash[:error] = "Password is a mandatory field"
-      redirect_to edit_user_path(@user)
+      render :edit
     elsif @user.authenticated?(params[:user][:password])
       if @user.update(user_params) && params[:commit] == "Delete account"
         redirect_to delete_account_path(@user)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -40,7 +40,7 @@ Rails.application.routes.draw do
   post '/events/:event_id/applications:id/revert', to: 'applications#revert', as: :revert_event_application
   get '/events/:event_id/continue_as_guest', to: 'applications#continue_as_guest', as: :continue_as_guest
   delete 'users/:id', to: 'users#destroy', as: :destroy_user
-  get 'users/:id/delete', to: 'users#delete_account', as: :delete_account
+  post 'users/:id/delete', to: 'users#delete_account', as: :delete_account
 
   root 'home#home'
 end

--- a/test/integration/user_delete_account_page_test.rb
+++ b/test/integration/user_delete_account_page_test.rb
@@ -27,9 +27,7 @@ feature 'User Delete Account Page' do
     admin = make_admin
     sign_in_as_admin
 
-    visit delete_account_path(@user)
-
-    assert page.text.include?("We're sorry. You don't have permission to access this page.")
+    assert_raises(ActionController::RoutingError) { visit delete_account_path(@user) }
   end
 
   test 'that no user can access the delete account page of other users' do
@@ -42,16 +40,12 @@ feature 'User Delete Account Page' do
     fill_in 'Password', with: 'awesome_password'
     click_button 'Sign in'
 
-    visit delete_account_path(@user)
-
-    assert page.text.include?("We're sorry. You don't have permission to access this page.")
+    assert_raises(ActionController::RoutingError) { visit delete_account_path(@user) }
   end
 
   test 'that users can only access the delete account page via "Delete Account"-Button on their settings page' do
     sign_in_as_user
 
-    visit delete_account_path(@user)
-
-    assert page.text.include?("We're sorry. You don't have permission to access this page.")
+    assert_raises(ActionController::RoutingError) { visit delete_account_path(@user) }
   end
 end


### PR DESCRIPTION
This PR adds a validation if a user tries to submit a change in their account or delete it. 
- Improves the UX if a user has missed adding the password before clicking on "submit" or "delete".
- Prevents the users to access the delete-account page if the user has not validated before. 
- Also, I fixed the tests to pass.