### PR TITLE
updates sprockets from 3.7.1 to 3.7.2 to avoid vulnerability issues

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -254,7 +254,7 @@ GEM
     simplecov-html (0.10.2)
     spring (2.0.2)
       activesupport (>= 4.2)
-    sprockets (3.7.1)
+    sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
     sprockets-rails (3.2.1)
@@ -331,4 +331,4 @@ RUBY VERSION
    ruby 2.4.3p205
 
 BUNDLED WITH
-   1.16.1
+   1.16.2


### PR DESCRIPTION
This PR fixes a vulnerable dependency issue with the sprocket gem.