### PR TITLE
Delete applications after event date

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -80,7 +80,7 @@ class EventsController < ApplicationController
       @event.skip_validation = true
       delete_event_data
       unless @event.applications.count == 0
-        delete_application_data
+        @event.delete_application_data
       end
       redirect_to user_path(current_user)
     else
@@ -138,22 +138,5 @@ class EventsController < ApplicationController
         end
       end
       @event.update_attributes(columns)
-    end
-
-    def delete_application_data
-      application = @event.applications.first
-      attributes = application.attributes.keys - ["id", "event_id", "applicant_id", "created_at", "updated_at", "submitted", "deleted"]
-      columns = {deleted: true}
-      attributes.each do |attr|
-        if application[attr].class == TrueClass || application[attr].class == FalseClass
-          columns[attr] = false
-        else
-          columns[attr] = nil
-        end
-      end
-      @event.applications.each do |application|
-        application.skip_validation = true
-        application.update_attributes(columns)
-      end
     end
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -128,4 +128,21 @@ class Event < ApplicationRecord
   def self.number_of_events_per_country(country_rank)
     events_count = @sorted_events[-country_rank].last.count
   end
+
+  def delete_application_data
+    application = self.applications.first
+    attributes = application.attributes.keys - ["id", "event_id", "applicant_id", "created_at", "updated_at", "submitted", "deleted"]
+    columns = {deleted: true}
+    attributes.each do |attr|
+      if application[attr].class == TrueClass || application[attr].class == FalseClass
+        columns[attr] = false
+      else
+        columns[attr] = nil
+      end
+    end
+    self.applications.each do |application|
+      application.skip_validation = true
+      application.update_attributes(columns)
+    end
+  end
 end

--- a/app/services/past_event_date_service.rb
+++ b/app/services/past_event_date_service.rb
@@ -1,0 +1,5 @@
+class PastEventDateService
+  def self.delete_application_data_after_event
+    Event.approved.where(end_date: Time.zone.yesterday).delete_application_data
+  end
+end

--- a/lib/tasks/events.rake
+++ b/lib/tasks/events.rake
@@ -1,0 +1,10 @@
+namespace :events do
+  namespace :past_events do
+    desc "Deletes personal data from all event applications the day after an event took place"
+    task :delete_data => :environment do
+      puts "Deletes applications data..."
+      PastEventDateService.delete_application_data_after_event
+      puts "Deleted."
+    end
+  end
+end


### PR DESCRIPTION
PR includes new past_event_date_service and events.rake task to destroy all sensitive applications data of events that have taken place the day before. The task is supposed to run once a day.