### PR TITLE
Deletes applications after event took place

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -80,7 +80,7 @@ class EventsController < ApplicationController
       @event.skip_validation = true
       delete_event_data
       unless @event.applications.count == 0
-        delete_application_data
+        @event.delete_application_data
       end
       redirect_to user_path(current_user)
     else
@@ -138,22 +138,5 @@ class EventsController < ApplicationController
         end
       end
       @event.update_attributes(columns)
-    end
-
-    def delete_application_data
-      application = @event.applications.first
-      attributes = application.attributes.keys - ["id", "event_id", "applicant_id", "created_at", "updated_at", "submitted", "deleted"]
-      columns = {deleted: true}
-      attributes.each do |attr|
-        if application[attr].class == TrueClass || application[attr].class == FalseClass
-          columns[attr] = false
-        else
-          columns[attr] = nil
-        end
-      end
-      @event.applications.each do |application|
-        application.skip_validation = true
-        application.update_attributes(columns)
-      end
     end
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -128,4 +128,21 @@ class Event < ApplicationRecord
   def self.number_of_events_per_country(country_rank)
     events_count = @sorted_events[-country_rank].last.count
   end
+
+  def delete_application_data
+    application = self.applications.first
+    attributes = application.attributes.keys - ["id", "event_id", "applicant_id", "created_at", "updated_at", "submitted", "deleted"]
+    columns = {deleted: true}
+    attributes.each do |attr|
+      if application[attr].class == TrueClass || application[attr].class == FalseClass
+        columns[attr] = false
+      else
+        columns[attr] = nil
+      end
+    end
+    self.applications.each do |application|
+      application.skip_validation = true
+      application.update_attributes(columns)
+    end
+  end
 end

--- a/app/services/past_event_date_service.rb
+++ b/app/services/past_event_date_service.rb
@@ -1,5 +1,11 @@
 class PastEventDateService
+  # Looks for all events in the past week to overwrite applications for security
+  # just in case the task does not always run properly:
   def self.delete_application_data_after_event
-    Event.approved.where(end_date: Time.zone.yesterday).delete_application_data
+    Event.approved.where('end_date < ? AND end_date > ?', Time.zone.now, 1.week.ago).delete_application_data
+  end
+
+  def self.delete_all_past_events_application_data
+    Event.approved.past.delete_application_data
   end
 end

--- a/app/services/past_event_date_service.rb
+++ b/app/services/past_event_date_service.rb
@@ -2,10 +2,12 @@ class PastEventDateService
   # Looks for all events in the past week to overwrite applications for security
   # just in case the task does not always run properly:
   def self.delete_application_data_after_event
-    Event.approved.where('end_date < ? AND end_date > ?', Time.zone.now, 1.week.ago).delete_application_data
+    events = Event.approved.where('end_date < ? AND end_date > ?', Time.zone.now, 1.week.ago)
+    events.map { |e| e.delete_application_data }
   end
 
   def self.delete_all_past_events_application_data
-    Event.approved.past.delete_application_data
+    events = Event.approved.past
+    events.map { |e| e.delete_application_data }
   end
 end

--- a/app/services/past_event_date_service.rb
+++ b/app/services/past_event_date_service.rb
@@ -1,0 +1,5 @@
+class PastEventDateService
+  def self.delete_application_data_after_event
+    Event.approved.where(end_date: Time.zone.yesterday).delete_application_data
+  end
+end

--- a/lib/tasks/events.rake
+++ b/lib/tasks/events.rake
@@ -1,0 +1,10 @@
+namespace :events do
+  namespace :past_events do
+    desc "Deletes personal data from all event applications the day after an event took place"
+    task :delete_data => :environment do
+      puts "Deletes applications data..."
+      PastEventDateService.delete_application_data_after_event
+      puts "Deleted."
+    end
+  end
+end

--- a/lib/tasks/events.rake
+++ b/lib/tasks/events.rake
@@ -7,4 +7,13 @@ namespace :events do
       puts "Deleted."
     end
   end
+
+  namespace :all_past_events do
+    desc "Deletes personal data from all event applications of past events"
+    task :delete_all_data => :environment do
+      puts "Deletes all past applications data..."
+      PastEventDateService.delete_all_past_events_application_data
+      puts "All done."
+    end
+  end
 end

--- a/lib/tasks/events.rake
+++ b/lib/tasks/events.rake
@@ -1,6 +1,6 @@
 namespace :events do
   namespace :past_events do
-    desc "Deletes personal data from all event applications the day after an event took place"
+    desc "Deletes personal data from all event applications for events that took place during the last week"
     task :delete_data => :environment do
       puts "Deletes applications data..."
       PastEventDateService.delete_application_data_after_event

--- a/test/services/past_event_date_service_test.rb
+++ b/test/services/past_event_date_service_test.rb
@@ -1,0 +1,135 @@
+require 'test_helper'
+
+class PastEventDateServiceTest < ActiveSupport::TestCase
+  describe 'deletes application data for events that took place yesterday'  do
+    it 'overwrites correct applications' do
+      past_event = make_event(approved: true, name: 'Yesterdays Event')
+      old_past_event = make_event(approved: true, name: 'Old Event')
+      future_event = make_event(approved: true, end_date: 1.week.from_now)
+      user = make_user(email: 'user@example.com')
+      past_application = make_application(
+        past_event,
+        applicant_id: user.id,
+        email: user.email,
+        email_confirmation: user.email
+      )
+      old_past_application = make_application(
+        old_past_event,
+        applicant_id: user.id,
+        email: user.email,
+        email_confirmation: user.email
+      )
+      future_application = make_application(
+        future_event,
+        applicant_id: user.id,
+        email: user.email,
+        email_confirmation: user.email
+      )
+
+      past_event.update_attributes(start_date: Time.now.yesterday, end_date: Time.now.yesterday)
+      old_past_event.update_attributes(start_date: 2.weeks.ago, end_date: 2.weeks.ago)
+
+      assert_equal 'user@example.com', future_application.email
+      assert_equal 'user@example.com', past_application.email
+      assert_equal 'user@example.com', old_past_application.email
+
+      PastEventDateService.delete_application_data_after_event
+
+      future_application.reload
+      old_past_application.reload
+      past_application.reload
+
+      assert_equal 'user@example.com', future_application.email
+      assert_equal 'user@example.com', old_past_application.email
+      assert_nil past_application.email
+    end
+
+    it 'overwrites correct drafts' do
+      past_event = make_event(approved: true, name: 'Yesterdays Event')
+      future_event = make_event(approved: true, end_date: 1.week.from_now)
+      user = make_user(email: 'user@example.com')
+      past_draft = make_draft(
+        past_event,
+        applicant_id: user.id,
+        email: user.email,
+        email_confirmation: user.email
+      )
+      future_draft = make_draft(
+        future_event,
+        applicant_id: user.id,
+        email: user.email,
+        email_confirmation: user.email
+      )
+
+      past_event.update_attributes(start_date: Time.now.yesterday, end_date: Time.now.yesterday)
+
+      assert_equal 'user@example.com', future_draft.email
+      assert_equal 'user@example.com', past_draft.email
+
+      PastEventDateService.delete_application_data_after_event
+
+      future_draft.reload
+      past_draft.reload
+
+      assert_equal 'user@example.com', future_draft.email
+      assert_nil past_draft.email
+    end
+  end
+
+  describe 'deletes application data for all past events'  do
+    it 'covers correct deletion of all applications of past events' do
+      past_event_1 = make_event(approved: true, name: 'Yesterdays Event')
+      past_event_2 = make_event(approved: true, name: 'Old Event')
+      past_event_3 = make_event(approved: true, name: 'Older Event')
+      future_event = make_event(approved: true, end_date: 1.week.from_now)
+      user = make_user(email: 'user@example.com')
+      past_application_1 = make_application(
+        past_event_1,
+        applicant_id: user.id,
+        email: user.email,
+        email_confirmation: user.email
+      )
+      past_application_2 = make_draft(
+        past_event_2,
+        applicant_id: user.id,
+        email: user.email,
+        email_confirmation: user.email
+      )
+      past_application_3 = make_application(
+        past_event_3,
+        applicant_id: user.id,
+        email: user.email,
+        email_confirmation: user.email
+      )
+      future_application = make_application(
+        future_event,
+        applicant_id: user.id,
+        email: user.email,
+        email_confirmation: user.email
+      )
+
+      past_event_1.update_attributes(start_date: Time.now.yesterday, end_date: Time.now.yesterday)
+      past_event_2.update_attributes(start_date: 2.weeks.ago, end_date: 2.weeks.ago)
+      past_event_3.update_attributes(start_date: 1.year.ago, end_date: 1.year.ago)
+
+      assert_equal 3, Event.approved.past.count
+      assert_equal 3, Event.approved.past.map { |e| e.applications.count }.inject { |sum,n| sum += n }
+      assert_equal 'user@example.com', past_application_1.email
+      assert_equal 'user@example.com', past_application_2.email
+      assert_equal 'user@example.com', past_application_3.email
+      assert_equal 'user@example.com', future_application.email
+
+
+      PastEventDateService.delete_all_past_events_application_data
+
+      past_application_1.reload
+      past_application_2.reload
+      past_application_3.reload
+
+      assert_nil past_application_1.email
+      assert_nil past_application_2.email
+      assert_nil past_application_3.email
+      assert_equal 'user@example.com', future_application.email
+    end
+  end
+end


### PR DESCRIPTION
PR includes new past_event_date_service and events.rake task to destroy all sensitive applications data of events that have taken place the day before. The task is supposed to run once a day.