### PR TITLE
adds more info to admin annual report

### DIFF
--- a/lib/report_exporter.rb
+++ b/lib/report_exporter.rb
@@ -64,6 +64,18 @@ module ReportExporter
 
         results = Event.all.where('start_date <= ?', Date.new(year, 12, 31))
 
+        number_of_tickets_offered = results.map do |event|
+          event.number_of_tickets
+        end.inject { |sum,n| sum += n }
+
+        csv << ["Tickets offered", number_of_tickets_offered ]
+
+        number_of_tickets_provided = results.map do |event|
+          event.applications.where(status: "approved").count
+        end.inject { |sum,n| sum += n }
+
+        csv << ["Tickets provided via 'Travis Selection'", number_of_tickets_provided ]
+
         csv << ["Geographical distribution"]
 
         countries = results.pluck(:country).uniq


### PR DESCRIPTION
adds the number of tickets offered per year and number of tickets provided via the travis selection per year (this feature only counts applications starting from 6/2018) to the admins annual report csv