### PR TITLE
New category tag: Fields of interest

### DIFF
--- a/config/categories.yml
+++ b/config/categories.yml
@@ -5,7 +5,7 @@
 # they will be loaded into the database when running 'rake admin:categories:create'.
 # You can't delete or change them from here.
 
-programming language:
+programming languages:
   - C
   - C++
   - C#
@@ -38,7 +38,7 @@ programming language:
   - Scala
   - Swift
 
-language:
+languages:
   - English
   - German
   - French
@@ -48,3 +48,7 @@ language:
   - Russian
   - Portuguese
   - Polish
+
+fields of interest:
+  - Math
+  - Biology

--- a/config/categories.yml
+++ b/config/categories.yml
@@ -49,6 +49,6 @@ languages:
   - Portuguese
   - Polish
 
-fields of interest:
+fields of expertise:
   - Math
   - Biology


### PR DESCRIPTION
This PR creates a new tag category (field of interest). We need to run rake admin:categories:create in production after deployment for this to take place.
@alicetragedy would be great to have a list of fields of interest so we can have a bigger list in the yml and go directly to production after deployment.