### PR TITLE
Selection time left in applicant mailer

### DIFF
--- a/app/views/applicant_mailer/application_received.text.erb
+++ b/app/views/applicant_mailer/application_received.text.erb
@@ -2,7 +2,7 @@ Dear <%= @application.name %>,
 
 thank you for applying for a diversity ticket for <%= @application.event.name %> in <%= @application.event.city %>.
 
-We will contact you after the applications are closed and when the winners of the diversity tickets are raffled out. This might take a couple of weeks.
+We will contact you after the applications are closed and when the winners of the diversity tickets are raffled out. Every conference is different, so we can’t tell you for sure how much the selection process will take; two weeks from the application deadline usually give us enough time to process all applications.
 
 If you have further questions, you can reach us at foundation@travis-ci.org
 


### PR DESCRIPTION
Adds information to the application_received mailer about when the selection will be informed. This email is sent after an applicant has requested a new ticket for a conference. We are adding more detailed information about when the selection is handled to avoid possible frustration.