### PR TITLE
Applicants vs tickets notification

### DIFF
--- a/app/controllers/applications_controller.rb
+++ b/app/controllers/applications_controller.rb
@@ -107,7 +107,9 @@ class ApplicationsController < ApplicationController
     params[:guest]
   end
 
-  def ticket_capacity_notification
-    OrganizerMailer.ticket_capacity_reached(@event).deliver_later
+  def ticket_capacity_check
+    if @event.number_of_tickets == @event.applications.count - 1
+      OrganizerMailer.ticket_capacity_reached(@event).deliver_later
+    end
   end
 end

--- a/app/controllers/applications_controller.rb
+++ b/app/controllers/applications_controller.rb
@@ -110,7 +110,10 @@ class ApplicationsController < ApplicationController
 
   def ticket_capacity_check
     if @event.number_of_tickets == @event.applications.count - 1
-      OrganizerMailer.ticket_capacity_reached(@event).deliver_later
+      if (@event.organizer.capacity_email_notifications == "Always") || (@event.organizer.capacity_email_notifications == "Once" && @event.capacity_reminder_count == 0)
+        OrganizerMailer.ticket_capacity_reached(@event).deliver_later
+        @event.update_attributes(capacity_reminder_count: @event.capacity_reminder_count + 1)
+      end
     end
   end
 end

--- a/app/controllers/applications_controller.rb
+++ b/app/controllers/applications_controller.rb
@@ -54,6 +54,7 @@ class ApplicationsController < ApplicationController
     if @application.update(application_params)
       @application.update_attributes(submitted: true)
       ApplicantMailer.application_received(@application).deliver_later
+      ticket_capacity_check
       current_user ? (path = event_application_path(@event.id, @application.id)) : (path = @event)
       redirect_to path, notice: "You have successfully applied for #{@event.name}."
     else

--- a/app/controllers/applications_controller.rb
+++ b/app/controllers/applications_controller.rb
@@ -106,4 +106,8 @@ class ApplicationsController < ApplicationController
   def guest
     params[:guest]
   end
+
+  def ticket_capacity_notification
+    OrganizerMailer.ticket_capacity_reached(@event).deliver_later
+  end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -88,7 +88,8 @@ class UsersController < Clearance::UsersController
     def user_params
       params.require(:user).permit(:name, :email, :password, :new_password,
         :country, :country_email_notifications, :tag_email_notifications,
-        { :tag_ids => [] }, tags_attributes: [:id, :name, :category_id])
+        :capacity_email_notifications, { :tag_ids => [] },
+        tags_attributes: [:id, :name, :category_id])
     end
 
     def user_from_params

--- a/app/mailers/organizer_mailer.rb
+++ b/app/mailers/organizer_mailer.rb
@@ -8,4 +8,9 @@ class OrganizerMailer < ApplicationMailer
     @event = event
     mail(to: @event.organizer_email, subject: 'Your event has been approved.')
   end
+
+  def ticket_capacity_reached(event)
+    @event = event
+    mail(to: @event.organizer_email, subject: 'Your event received more applications than available tickets.')
+  end
 end

--- a/app/views/organizer_mailer/approved_event.text.erb
+++ b/app/views/organizer_mailer/approved_event.text.erb
@@ -2,6 +2,8 @@ Dear <%= @event.organizer_name %>,
 
 Your event <%= @event.name %> has been approved on diversitytickets.org and is now visible to the public. You can view it here: https://diversitytickets.org/events/<%= @event.id %>. As of now, applicants can apply for diversity tickets by clicking on the "Apply" link and filling out the form.
 
+You have the option of receiving an email reminder to be notified when the number of submitted applications for your event has exceeded the amount of tickets you provide. In order to receive this information, please adjust your email preferences in your account settings to allow us to send you notifications: https://diversitytickets.org/users/<%= @event.organizer_id %>/edit
+
 If you have any more questions, please read the FAQ (https://diversitytickets.org/faq). If you need more help, contact foundation@travis-ci.org.
 
 The Travis Foundation Team

--- a/app/views/organizer_mailer/ticket_capacity_reached.text.erb
+++ b/app/views/organizer_mailer/ticket_capacity_reached.text.erb
@@ -1,0 +1,13 @@
+Dear <%= @event.organizer_name %>,
+
+Your event <%= @event.name %> has received more applications than there are diversity tickets available. You can view the current count of received applications here: https://diversitytickets.org/users/<%= @event.organizer_id %>.
+
+Would you like to open up more tickets for <%= @event.name %>?
+ -> Go to https://diversitytickets.org/events/<%= @event.id %>/edit to edit the number of available diversity tickets. When you are done make sure to click "Submit changes".
+
+If you have any more questions, please read the FAQ (https://diversitytickets.org/faq).
+If you need more help, contact foundation@travis-ci.org.
+
+The Travis Foundation Team
+
+-

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -31,7 +31,7 @@
         <p><%= form.check_box :country_email_notifications %> <%= t('.receive-emails-country') %></p>
         <p><%= form.check_box :tag_email_notifications %> <%= t('.receive-emails-tag') %><p>
         <h3><%= t(".for-organizers") %></h3>
-        <h5><%= t(".capacity-email-notifictions-info") %></h5>
+        <h5><%= t(".capacity-email-notifications-info") %></h5>
         <p><%= form.radio_button :capacity_email_notifications, "OFF", checked: (@user.capacity_email_notifications == "OFF" ? true : false)%>
           <%= t('.receive-no-capacity-reminders') %></p>
         <p><%= form.radio_button :capacity_email_notifications, "Always", checked: (@user.capacity_email_notifications == "Always" ? true : false) %>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -31,12 +31,13 @@
         <p><%= form.check_box :country_email_notifications %> <%= t('.receive-emails-country') %></p>
         <p><%= form.check_box :tag_email_notifications %> <%= t('.receive-emails-tag') %><p>
         <h3><%= t(".for-organizers") %></h3>
+        <h5><%= t(".capacity-email-notifictions-info") %></h5>
         <p><%= form.radio_button :capacity_email_notifications, "OFF", checked: (@user.capacity_email_notifications == "OFF" ? true : false)%>
           <%= t('.receive-no-capacity-reminders') %></p>
+        <p><%= form.radio_button :capacity_email_notifications, "Always", checked: (@user.capacity_email_notifications == "Always" ? true : false) %>
+          <%= t('.receive-all-capacity-reminders') %></p>
         <p><%= form.radio_button :capacity_email_notifications, "Once", checked: (@user.capacity_email_notifications == "Once" ? true : false) %>
           <%= t('.receive-capacity-reminders-once') %></p>
-        <p><%= form.radio_button :capacity_email_notifications, "Always", checked: (@user.capacity_email_notifications == "Always" ? true : false) %> 
-          <%= t('.receive-all-capacity-reminders') %></p>
     </section>
 
     <section class="box col-6">

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -30,6 +30,13 @@
         <h2><%= t(".email-notifications") %></h2>
         <p><%= form.check_box :country_email_notifications %> <%= t('.receive-emails-country') %></p>
         <p><%= form.check_box :tag_email_notifications %> <%= t('.receive-emails-tag') %><p>
+        <h3><%= t(".for-organizers") %></h3>
+        <p><%= form.radio_button :capacity_email_notifications, "OFF", checked: (@user.capacity_email_notifications == "OFF" ? true : false)%>
+          <%= t('.receive-no-capacity-reminders') %></p>
+        <p><%= form.radio_button :capacity_email_notifications, "Once", checked: (@user.capacity_email_notifications == "Once" ? true : false) %>
+          <%= t('.receive-capacity-reminders-once') %></p>
+        <p><%= form.radio_button :capacity_email_notifications, "Always", checked: (@user.capacity_email_notifications == "Always" ? true : false) %> 
+          <%= t('.receive-all-capacity-reminders') %></p>
     </section>
 
     <section class="box col-6">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -41,12 +41,17 @@ en:
               invalid: "should be a full URL, e.g. https://myconference.com/code_of_conduct"
   users:
     edit:
+      capacity-email-notifictions-info: "We would like to inform you once your event received more applications than the number of tickets you made available via Diversity Tickets to give you the opportunity to increase the number of tickets for your event."
       country: "Country"
       email-notifications: "Email notifications"
+      for-organizers: "For organizers"
       name: "Name"
       password: "Password"
+      receive-all-capacity-reminders: "Yes, please!"
+      receive-capacity-reminders-once: "Yes, but only once per event"
       receive-emails-country: "Yes, I want to get email notifications about new events taking place in the country I’ve selected for my account"
       receive-emails-tag: "Yes, I want to get email notifications about new events that match my fields of interest"
+      receive-no-capacity-reminders: "No, thank you."
       save-changes: "Save changes"
       title: "Account settings"
     events:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -41,7 +41,7 @@ en:
               invalid: "should be a full URL, e.g. https://myconference.com/code_of_conduct"
   users:
     edit:
-      capacity-email-notifictions-info: "We would like to inform you once your event received more applications than the number of tickets you made available via Diversity Tickets to give you the opportunity to increase the number of tickets for your event."
+      capacity-email-notifications-info: "We would like to inform you once your event received more applications than the number of tickets you made available via Diversity Tickets to give you the opportunity to increase the number of tickets for your event."
       country: "Country"
       email-notifications: "Email notifications"
       for-organizers: "For organizers"

--- a/db/migrate/20180808082453_add_capacity_email_notifications_to_users.rb
+++ b/db/migrate/20180808082453_add_capacity_email_notifications_to_users.rb
@@ -1,0 +1,5 @@
+class AddCapacityEmailNotificationsToUsers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :capacity_email_notifications, :string, default: "OFF"
+  end
+end

--- a/db/migrate/20180808083204_add_capacity_reminder_count_to_events.rb
+++ b/db/migrate/20180808083204_add_capacity_reminder_count_to_events.rb
@@ -1,0 +1,5 @@
+class AddCapacityReminderCountToEvents < ActiveRecord::Migration[5.2]
+  def change
+    add_column :events, :capacity_reminder_count, :integer, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_06_25_160332) do
+ActiveRecord::Schema.define(version: 2018_08_08_082453) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -55,7 +55,7 @@ ActiveRecord::Schema.define(version: 2018_06_25_160332) do
     t.text "code_of_conduct"
     t.string "city"
     t.string "country"
-    t.date "deadline"
+    t.datetime "deadline"
     t.integer "number_of_tickets"
     t.boolean "ticket_funded", default: false, null: false
     t.boolean "accommodation_funded", default: false, null: false
@@ -68,6 +68,7 @@ ActiveRecord::Schema.define(version: 2018_06_25_160332) do
     t.string "state_province"
     t.integer "organizer_id"
     t.boolean "deleted", default: false
+    t.string "approved_tickets"
     t.index ["organizer_id"], name: "index_events_on_organizer_id"
   end
 
@@ -109,6 +110,7 @@ ActiveRecord::Schema.define(version: 2018_06_25_160332) do
     t.boolean "country_email_notifications", default: false
     t.string "country"
     t.boolean "tag_email_notifications", default: false
+    t.string "capacity_email_notifications", default: "OFF"
     t.index ["email"], name: "index_users_on_email"
     t.index ["remember_token"], name: "index_users_on_remember_token"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_08_08_082453) do
+ActiveRecord::Schema.define(version: 2018_08_08_083204) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -69,6 +69,7 @@ ActiveRecord::Schema.define(version: 2018_08_08_082453) do
     t.integer "organizer_id"
     t.boolean "deleted", default: false
     t.string "approved_tickets"
+    t.integer "capacity_reminder_count", default: 0
     t.index ["organizer_id"], name: "index_events_on_organizer_id"
   end
 

--- a/lib/report_exporter.rb
+++ b/lib/report_exporter.rb
@@ -130,6 +130,7 @@ module ReportExporter
         "Updated at",
         "Email notifications: Local event, on?",
         "Email notifications: Events about fields of interest, on?",
+        "Email notifictions: Send reminder when ticket capacity is reached",
         "Number of applications"
       ]
 
@@ -142,6 +143,7 @@ module ReportExporter
         result["updated_at"],
         result["country_email_notifications"],
         result["tag_email_notifications"],
+        result["capacity_email_notifications"],
         result.applications.count
       ]
 


### PR DESCRIPTION
Adds mailer to inform organizers that the amount of applications received is higher than the amount of provided tickets and suggests to open more tickets to diversity tickets.