### PR TITLE
Time zone management

### DIFF
--- a/app/assets/javascripts/datepicker.js
+++ b/app/assets/javascripts/datepicker.js
@@ -3,6 +3,5 @@ $(document).ready(function(){
   $( "#event_start_date" ).change(function() {
     var date = $("input#event_start_date").val()
     $("#event_end_date").val(date);
-    $("#event_deadline").val(date);
   });
 });

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -37,6 +37,10 @@ module ApplicationHelper
     date.strftime("%B #{date.mday.ordinalize}, %Y")
   end
 
+  def format_datetime(datetime)
+    datetime.strftime("%B #{datetime.mday.ordinalize}, %Y %H:%M:%S %Z")
+  end
+
   def format_date_range_same_month(start_date, end_date)
     start_date.strftime("%B #{start_date.mday.ordinalize}") + " to #{end_date.mday.ordinalize}, #{end_date.year}"
   end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -44,20 +44,20 @@ class Event < ApplicationRecord
     where('end_date < ?', now)
   end
 
-  def self.open(now = DateTime.now)
+  def self.open(now = DateTime.current)
     where('deadline >= ?', now)
   end
 
-  def self.closed(now = DateTime.now)
+  def self.closed(now = DateTime.current)
     where('deadline < ?', now)
   end
 
-  def self.deadline_yesterday(now = DateTime.now)
-    where('deadline = ?', now - 1.day)
+  def self.deadline_yesterday(now = DateTime.current)
+    where('deadline BETWEEN ? AND ?', (now - 1.day).beginning_of_day, (now - 1.day).end_of_day)
   end
 
-  def self.deadline_in_two_days(now = DateTime.now)
-    where('deadline = ?', now + 2.days)
+  def self.deadline_in_two_days(now = DateTime.current)
+    where('deadline BETWEEN ? AND ?', (now + 2.days).beginning_of_day, (now + 2.days).end_of_day)
   end
 
   def self.created_current_year(now = Time.zone.now)

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -12,7 +12,7 @@ class Event < ApplicationRecord
   validates :organizer_name, :description, :name, :website, :code_of_conduct, :city, :country, presence: true, unless: :skip_validation
   validates :start_date, date: true, presence: true, unless: :skip_validation
   validates :end_date, date: { after_or_equal_to: :start_date }, presence: true, unless: :skip_validation
-  validates :deadline, date: { before_or_equal_to: :end_date }, presence: true, unless: :skip_validation
+  validates :deadline, date: { before: :end_date }, presence: true, unless: :skip_validation
   validates :organizer_email, confirmation: true, format: { with: /.+@.+\..+/ }, presence: true, unless: :skip_validation
   validates :organizer_email_confirmation, presence: true, on: :create, unless: :skip_validation
   validates :website, :code_of_conduct, format: { with: /(http|https):\/\/.+\..+/ }, unless: :skip_validation

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -69,19 +69,15 @@ class Event < ApplicationRecord
   end
 
   def open?
-    deadline_as_time >= Time.now
+    deadline >= Time.now
   end
 
   def closed?
-    deadline_as_time < Time.now
+    deadline < Time.now
   end
 
   def past?
     end_date < Time.now
-  end
-
-  def deadline_as_time
-    (deadline + 1).in_time_zone("UTC")
   end
 
   def location

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -10,8 +10,9 @@ class Event < ApplicationRecord
   has_many :interested_users, -> { distinct }, through: :tag_taggings, source: 'user'
 
   validates :organizer_name, :description, :name, :website, :code_of_conduct, :city, :country, presence: true, unless: :skip_validation
-  validates :start_date, :deadline, date: true, presence: true, unless: :skip_validation
+  validates :start_date, date: true, presence: true, unless: :skip_validation
   validates :end_date, date: { after_or_equal_to: :start_date }, presence: true, unless: :skip_validation
+  validates :deadline, date: { before_or_equal_to: :end_date }, presence: true, unless: :skip_validation
   validates :organizer_email, confirmation: true, format: { with: /.+@.+\..+/ }, presence: true, unless: :skip_validation
   validates :organizer_email_confirmation, presence: true, on: :create, unless: :skip_validation
   validates :website, :code_of_conduct, format: { with: /(http|https):\/\/.+\..+/ }, unless: :skip_validation

--- a/app/views/events/_application_details.html.erb
+++ b/app/views/events/_application_details.html.erb
@@ -10,7 +10,7 @@
 
   <div class="detail-pair">
     <strong>Deadline for applications</strong>
-    <%= format_date(@event.deadline) %> (midnight UTC)
+    <%= format_datetime(@event.deadline) %>
   </div>
 
   <div class="detail-pair">

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -61,8 +61,10 @@
   - Additional organizational info
   - ..." %>
     <div class="two-columns">
-      <%= f.form_field :date_select, :deadline, 'Deadline for application', class: ['right'], placeholder: "dd.mm.yyyy", min: Date.today %>
-      <%= f.form_field :time_select, :deadline, 'Time (hh:mm UTC)', class: ['right'], ignore_date: true, default: {hour: '00', minute: '00'}, minute_step: 15 %>
+      <%= f.form_field :date_select, :deadline, 'Deadline for application', class: ['right'],
+          include_blank: true, default: nil, start_year: Date.today.year, use_short_month: true %>
+      <%= f.form_field :time_select, :deadline, 'Time (hh:mm UTC)', class: ['right'],
+          ignore_date: true, default: {hour: '00', minute: '00'}, minute_step: 15 %>
     </div>
       <%= f.form_field :number_field, :number_of_tickets, 'Number of available diversity tickets', min: 1 %>
 

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -60,7 +60,10 @@
     E.g.: The ticket is valid for both conference days, ...
   - Additional organizational info
   - ..." %>
-      <%= f.form_field :date_field, :deadline, 'Deadline for application', class: ['right'], placeholder: "dd.mm.yyyy", min: Date.today %>
+    <div class="two-columns">
+      <%= f.form_field :date_select, :deadline, 'Deadline for application', class: ['right'], placeholder: "dd.mm.yyyy", min: Date.today %>
+      <%= f.form_field :time_select, :deadline, 'Time (hh:mm UTC)', class: ['right'], ignore_date: true, default: {hour: '00', minute: '00'}, minute_step: 15 %>
+    </div>
       <%= f.form_field :number_field, :number_of_tickets, 'Number of available diversity tickets', min: 1 %>
 
       <h3 class="box-subtitle">Funded</h3>

--- a/db/migrate/20180807082714_change_date_format_in_events.rb
+++ b/db/migrate/20180807082714_change_date_format_in_events.rb
@@ -1,0 +1,5 @@
+class ChangeDateFormatInEvents < ActiveRecord::Migration[5.2]
+  def change
+    change_column :events, :deadline, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_06_25_160332) do
+ActiveRecord::Schema.define(version: 2018_08_07_082714) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -55,7 +55,7 @@ ActiveRecord::Schema.define(version: 2018_06_25_160332) do
     t.text "code_of_conduct"
     t.string "city"
     t.string "country"
-    t.date "deadline"
+    t.datetime "deadline"
     t.integer "number_of_tickets"
     t.boolean "ticket_funded", default: false, null: false
     t.boolean "accommodation_funded", default: false, null: false
@@ -68,6 +68,7 @@ ActiveRecord::Schema.define(version: 2018_06_25_160332) do
     t.string "state_province"
     t.integer "organizer_id"
     t.boolean "deleted", default: false
+    t.string "approved_tickets"
     t.index ["organizer_id"], name: "index_events_on_organizer_id"
   end
 

--- a/test/controllers/applications_controller_test.rb
+++ b/test/controllers/applications_controller_test.rb
@@ -146,7 +146,7 @@ class ApplicationsControllerTest < ActionController::TestCase
       user = make_user
       event = make_event(organizer_id: user.id)
       application = make_application(event, applicant_id: user.id)
-      event.update_attributes(start_date: 1.week.ago, end_date: 1.week.ago)
+      event.update_attributes(start_date: 1.week.ago, end_date: 1.week.ago, deadline: 10.days.ago)
 
       sign_in_as(user)
 

--- a/test/controllers/events_controller_test.rb
+++ b/test/controllers/events_controller_test.rb
@@ -241,14 +241,14 @@ class EventsControllerTest < ActionController::TestCase
       future_approved_event = make_event(
         start_date: 1.week.ago,
         end_date: 10.days.from_now,
-        deadline: 10.days.from_now,
+        deadline: 9.days.from_now,
         approved: true,
         name: 'Approved'
       )
       future_unapproved_event = make_event(
         start_date: 1.week.ago,
         end_date: 10.days.from_now,
-        deadline: 10.days.from_now,
+        deadline: 9.days.from_now,
         approved: false,
         name: 'Unapproved'
       )
@@ -510,7 +510,7 @@ class EventsControllerTest < ActionController::TestCase
     it 'deletes all the attributes of the event except the id and the country' do
       organizer = make_user
       event = make_event(name: "HOLA", organizer_id: organizer.id)
-      event.update_attributes(start_date: 2.weeks.ago, end_date: 1.week.ago)
+      event.update_attributes(start_date: 2.weeks.ago, end_date: 1.week.ago, deadline: 9.days.ago)
       event_id = event.id
       sign_in_as(organizer)
 
@@ -527,7 +527,7 @@ class EventsControllerTest < ActionController::TestCase
       event = make_event(organizer_id: organizer.id)
       applicant = make_user(email: "other@example.com")
       application = make_application(event, applicant_id: applicant.id )
-      event.update_attributes(start_date: 2.weeks.ago, end_date: 1.week.ago)
+      event.update_attributes(start_date: 2.weeks.ago, end_date: 1.week.ago, deadline: 9.days.ago)
       application_id = application.id
 
       sign_in_as(organizer)

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -97,7 +97,7 @@ class UsersControllerTest < ActionController::TestCase
       user = make_user
       approved_event = make_event(approved: true, organizer_id: user.id, end_date: 10.days.from_now)
       unapproved_event = make_event(organizer_id: user.id, end_date: 10.days.from_now)
-      past_event = make_event(organizer_id: user.id, start_date: Time.now.yesterday, end_date: Time.now.yesterday)
+      past_event = make_event(organizer_id: user.id, start_date: Time.now.yesterday, end_date: Time.now.yesterday, deadline: 2.days.ago)
 
       categorized_user_events = {
         approved: user.events.approved.upcoming,

--- a/test/lib/report_exporter_test.rb
+++ b/test/lib/report_exporter_test.rb
@@ -38,7 +38,7 @@ class ReportExporterTest < ActiveSupport::TestCase
     end
 
     it 'does not include events where applications are still open' do
-      @event.update(deadline: 2.days.from_now)
+      @event.update(end_date: 3.days.from_now, deadline: 2.days.from_now)
 
       report = ReportExporter.events_report.split("\n")
 

--- a/test/models/event_test.rb
+++ b/test/models/event_test.rb
@@ -14,7 +14,7 @@ class EventTest < ActiveSupport::TestCase
 
     it 'deadline is midnight UTC' do
       event = Event.new(deadline: Date.new(2016, 4, 8))
-      assert_equal event.deadline, ActiveSupport::TimeZone['UTC'].local(2016, 4, 8, 0, 0, 0)
+      assert_equal ActiveSupport::TimeZone['UTC'].local(2016, 4, 8, 0, 0, 0), event.deadline
     end
   end
 
@@ -87,57 +87,57 @@ class EventTest < ActiveSupport::TestCase
 
   describe 'upcoming' do
     it 'gets event with enddate on the same day' do
-      make_event(start_date: '2016-07-24', end_date: '2016-07-25')
+      make_event(start_date: '2016-07-24', end_date: '2016-07-25', deadline: '2016-07-24')
 
-      assert_equal Event.upcoming('2016-07-25 23:59:59').length, 1
+      assert_equal 1, Event.upcoming('2016-07-25 23:59:59').length
     end
 
     it 'does not get event with enddate on the day before' do
-      make_event(start_date: '2016-07-24', end_date: '2016-07-25')
+      make_event(start_date: '2016-07-24', end_date: '2016-07-25', deadline: '2016-07-24')
 
-      assert_equal Event.upcoming('2016-07-26 00:00:00').length, 0
+      assert_equal 0, Event.upcoming('2016-07-26 00:00:00').length
     end
   end
 
   describe 'past' do
     it 'does not get event with enddate on the same day' do
-      make_event(start_date: '2016-07-24', end_date: '2016-07-25')
+      make_event(start_date: '2016-07-24', end_date: '2016-07-25', deadline: '2016-07-24')
 
-      assert_equal Event.past('2016-07-25 23:59:59').length, 0
+      assert_equal 0, Event.past('2016-07-25 23:59:59').length
     end
 
     it 'gets event with enddate on the day before' do
-      make_event(start_date: '2016-07-24', end_date: '2016-07-25')
+      make_event(start_date: '2016-07-24', end_date: '2016-07-25', deadline: '2016-07-24')
 
-      assert_equal Event.past('2016-07-26 00:00:00').length, 1
+      assert_equal 1, Event.past('2016-07-26 00:00:00').length
     end
   end
 
   describe 'open' do
     it 'gets event with deadline on the same day' do
-      make_event(deadline: '2016-07-25')
+      make_event(deadline: '2016-07-26')
 
-      assert_equal Event.open('2016-07-25 23:59:59').length, 1
+      assert_equal 1, Event.open('2016-07-25 23:59:59').length
     end
 
     it 'does not get event with deadline on the day before' do
-      make_event(deadline: '2016-07-25')
+      make_event(deadline: '2016-07-26')
 
-      assert_equal Event.open('2016-07-26 00:00:00').length, 0
+      assert_equal 0, Event.open('2016-07-26 00:00:01').length
     end
   end
 
   describe 'closed' do
     it 'does not get event with deadline on the same day' do
-      make_event(deadline: '2016-07-25')
+      make_event(deadline: '2016-07-26')
 
-      assert_equal Event.closed('2016-07-25 23:59:59').length, 0
+      assert_equal 0, Event.closed('2016-07-25 23:59:59').length
     end
 
     it 'gets event with deadline on the day before' do
-      make_event(deadline: '2016-07-25')
+      make_event(deadline: '2016-07-26')
 
-      assert_equal Event.closed('2016-07-26 00:00:00').length, 1
+      assert_equal 1, Event.closed('2016-07-26 00:00:01').length
     end
   end
 
@@ -154,12 +154,12 @@ class EventTest < ActiveSupport::TestCase
   describe 'location' do
     it 'formats the loacation for event without state/province' do
       event = Event.new(city: 'Berlin', country: 'Germany', state_province: '')
-      assert_equal event.location, 'Berlin, Germany'
+      assert_equal 'Berlin, Germany', event.location
     end
 
     it 'formats the loacation for event with state/province' do
       event = Event.new(city: 'Berlin', country: 'United States', state_province: 'Wisconsin')
-      assert_equal event.location, 'Berlin, Wisconsin, United States'
+      assert_equal 'Berlin, Wisconsin, United States', event.location
     end
   end
 
@@ -167,12 +167,12 @@ class EventTest < ActiveSupport::TestCase
   describe 'twitter_handle' do
     it 'leading @\'s are removed before saving to the database' do
       event = make_event(twitter_handle: '@lisbethmarianne')
-      assert_equal event.twitter_handle, 'lisbethmarianne'
+      assert_equal 'lisbethmarianne', event.twitter_handle
     end
 
      it 'is not altered if there is no leading @' do
       event = make_event(twitter_handle: 'lisbethmarianne')
-      assert_equal event.twitter_handle, 'lisbethmarianne'
+      assert_equal 'lisbethmarianne', event.twitter_handle
     end
 
     it 'event can be saved with no twitter handle' do

--- a/test/models/event_test.rb
+++ b/test/models/event_test.rb
@@ -14,7 +14,7 @@ class EventTest < ActiveSupport::TestCase
 
     it 'deadline is midnight UTC' do
       event = Event.new(deadline: Date.new(2016, 4, 8))
-      assert_equal event.deadline_as_time, ActiveSupport::TimeZone['UTC'].local(2016, 4, 9, 0, 0, 0)
+      assert_equal event.deadline, ActiveSupport::TimeZone['UTC'].local(2016, 4, 8, 0, 0, 0)
     end
   end
 

--- a/test/services/past_event_date_service_test.rb
+++ b/test/services/past_event_date_service_test.rb
@@ -26,7 +26,7 @@ class PastEventDateServiceTest < ActiveSupport::TestCase
         email_confirmation: user.email
       )
 
-      past_event.update_attributes(start_date: Time.now.yesterday, end_date: Time.now.yesterday)
+      past_event.update_attributes(start_date: Time.now.yesterday, end_date: Time.now.yesterday, deadline: 2.days.ago)
       old_past_event.update_attributes(start_date: 2.weeks.ago, end_date: 2.weeks.ago)
 
       assert_equal 'user@example.com', future_application.email
@@ -61,7 +61,7 @@ class PastEventDateServiceTest < ActiveSupport::TestCase
         email_confirmation: user.email
       )
 
-      past_event.update_attributes(start_date: Time.now.yesterday, end_date: Time.now.yesterday)
+      past_event.update_attributes(start_date: Time.now.yesterday, end_date: Time.now.yesterday, deadline: 2.days.ago)
 
       assert_equal 'user@example.com', future_draft.email
       assert_equal 'user@example.com', past_draft.email
@@ -108,9 +108,9 @@ class PastEventDateServiceTest < ActiveSupport::TestCase
         email_confirmation: user.email
       )
 
-      past_event_1.update_attributes(start_date: Time.now.yesterday, end_date: Time.now.yesterday)
-      past_event_2.update_attributes(start_date: 2.weeks.ago, end_date: 2.weeks.ago)
-      past_event_3.update_attributes(start_date: 1.year.ago, end_date: 1.year.ago)
+      past_event_1.update_attributes(start_date: Time.now.yesterday, end_date: Time.now.yesterday, deadline: 2.days.ago)
+      past_event_2.update_attributes(start_date: 2.weeks.ago, end_date: 2.weeks.ago, deadline: 3.weeks.ago)
+      past_event_3.update_attributes(start_date: 1.year.ago, end_date: 1.year.ago, deadline: 2.years.ago)
 
       assert_equal 3, Event.approved.past.count
       assert_equal 3, Event.approved.past.map { |e| e.applications.count }.inject { |sum,n| sum += n }

--- a/test/workers/twitter_worker_test.rb
+++ b/test/workers/twitter_worker_test.rb
@@ -6,8 +6,7 @@ class TwitterWorkerTest < ActiveSupport::TestCase
   it 'sends a tweet with name if event has no twitter handle' do
     event = make_event(
       name: 'Awesome Event',
-      id: 101,
-      deadline: 2.weeks.from_now
+      id: 101
     )
 
     event.reload
@@ -21,7 +20,6 @@ class TwitterWorkerTest < ActiveSupport::TestCase
     event = make_event(
       name: 'Awesome Event',
       id: 101,
-      deadline: 2.weeks.from_now,
       twitter_handle: 'awesome_event'
     )
 
@@ -35,8 +33,7 @@ class TwitterWorkerTest < ActiveSupport::TestCase
   it 'uses shortened name if name is longer than 30 characters' do
      event = make_event(
       name: 'Super Duper Mega Crazy Awesome Event',
-      id: 101,
-      deadline: 2.weeks.from_now
+      id: 101
     )
 
     event.reload


### PR DESCRIPTION
This PR changes the deadline attribute in the events table from date to datetime in order to allow organizers to specify an exact time for their events deadline (before this we had midnight UTC for all events deadlines).
- Adds separate form input for deadline date and time in events form
- Adjusts event model methods, tests and services accordingly