### PR TITLE
Fixes autofill bug for admin event form view 

### DIFF
--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -4,11 +4,10 @@
     <section class="box">
       <h2 class="box-title box-noborder">Organizer details</h2>
       <p class="border">Not shown to the public.</p>
-      <%= f.form_field :text_field, :organizer_name, 'Full name', value: (current_user.name != nil) ? current_user.name : '' %>
-      <%= f.form_field :text_field, :organizer_email, 'Email', value: current_user.email %>
-
+      <%= f.form_field :text_field, :organizer_name, 'Full name', value: @event.organizer_name ? @event.organizer_name : ((current_user.name != nil) ? current_user.name : '')%>
+      <%= f.form_field :text_field, :organizer_email, 'Email', value: @event.organizer_email ? @event.organizer_email : current_user.email %>  
       <% if action_name == 'new' || action_name == 'preview' %>
-        <%= f.form_field :text_field, :organizer_email_confirmation, 'Email confirmation', value: current_user.email %>
+        <%= f.form_field :text_field, :organizer_email_confirmation, 'Email confirmation', value: @event.organizer_email ? @event.organizer_email : current_user.email %>
       <% end %>
     </section>
 


### PR DESCRIPTION
The event form will only fill in admins name or email if it is a new event and/or does not have previously saved organizer details.