### PR TITLE
Delete past events

### DIFF
--- a/app/controllers/admin_events_controller.rb
+++ b/app/controllers/admin_events_controller.rb
@@ -14,8 +14,8 @@ class AdminEventsController < ApplicationController
     @categorized_events = {
       "Unapproved events" => Event.unapproved.upcoming.order(:deadline),
       "Approved events" => Event.approved.upcoming.order(:deadline),
-      "Past approved events"=> Event.approved.past.order(:deadline),
-      "Past unapproved events" => Event.unapproved.past.order(:deadline)
+      "Past approved events"=> Event.approved.past.order(:deadline).active,
+      "Past unapproved events" => Event.unapproved.past.order(:deadline).active
     }
     @approved_events_deadline = {
       "Open deadline:" => Event.approved.upcoming.open.order(:deadline),

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -127,7 +127,7 @@ class EventsController < ApplicationController
     end
 
     def delete_event_data
-      attributes = @event.attributes.keys - ["id", "created_at", "updated_at", "deleted", "country"]
+      attributes = @event.attributes.keys - ["id", "created_at", "updated_at", "deleted", "start_date", "end_date", "country", "application_process", "number_of_tickets", "approved_tickets"]
       columns = {deleted: true}
       attributes.each do |attr|
         if @event[attr].class == TrueClass || @event[attr].class == FalseClass

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -127,7 +127,7 @@ class EventsController < ApplicationController
     end
 
     def delete_event_data
-      attributes = @event.attributes.keys - ["id", "created_at", "updated_at", "deleted", "start_date", "end_date", "country", "application_process", "number_of_tickets", "approved_tickets"]
+      attributes = @event.attributes.keys - ["id", "created_at", "updated_at", "deleted", "start_date", "end_date", "country", "application_process", "number_of_tickets", "approved_tickets", "approved"]
       columns = {deleted: true}
       attributes.each do |attr|
         if @event[attr].class == TrueClass || @event[attr].class == FalseClass

--- a/test/integration/event_page_test.rb
+++ b/test/integration/event_page_test.rb
@@ -39,7 +39,7 @@ feature 'Event' do
 
     visit event_path(@event.id)
 
-    assert page.text.include?('You are not allowed to access this event')
+    assert page.text.include?('This event has been deleted by the organizer')
     assert root_path, current_path
   end
 


### PR DESCRIPTION
This PR makes sure that certain attributes with non-sensitive data, which are important for the statistics report, are not deleted/overwritten when an event is being deleted.