### PR TITLE
Time zone management

### DIFF
--- a/app/mailers/admin_mailer.rb
+++ b/app/mailers/admin_mailer.rb
@@ -6,7 +6,7 @@ class AdminMailer < ApplicationMailer
 
   def upcoming_event_deadline(event, email)
     @event = event
-    mail(to: email, subject: "#{@event.name} deadline in two days.")
+    mail(to: email, subject: "#{@event.name} deadline is approaching.")
   end
 
   def passed_event_deadline(event, email)

--- a/app/mailers/applicant_mailer.rb
+++ b/app/mailers/applicant_mailer.rb
@@ -6,6 +6,6 @@ class ApplicantMailer < ApplicationMailer
 
 	def deadline_reminder(application)
 		@application = application
-		mail(to: @application.email, subject: "#{@application.event.name} deadline in two days.")
+		mail(to: @application.email, subject: "#{@application.event.name} deadline is approaching.")
 	end
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -56,8 +56,8 @@ class Event < ApplicationRecord
     where('deadline BETWEEN ? AND ?', (now - 1.day).beginning_of_day, (now - 1.day).end_of_day)
   end
 
-  def self.deadline_in_two_days(now = DateTime.current)
-    where('deadline BETWEEN ? AND ?', (now + 2.days).beginning_of_day, (now + 2.days).end_of_day)
+  def self.deadline_in_three_days(now = DateTime.current)
+    where('deadline BETWEEN ? AND ?', (now + 3.days).beginning_of_day, (now + 3.days).end_of_day)
   end
 
   def self.created_current_year(now = Time.zone.now)

--- a/app/services/deadline_mail_service.rb
+++ b/app/services/deadline_mail_service.rb
@@ -1,6 +1,6 @@
 class DeadlineMailService
   def self.send_deadline_mail
-    Event.approved.deadline_in_two_days.each do |event|
+    Event.approved.deadline_in_three_days.each do |event|
       User.admin.each do |user|
         AdminMailer.upcoming_event_deadline(event, user.email).deliver_later
       end
@@ -8,7 +8,7 @@ class DeadlineMailService
   end
 
   def self.send_deadline_reminder_applicants
-    Event.approved.deadline_in_two_days.each do |event|
+    Event.approved.deadline_in_three_days.each do |event|
       event.applications.where(submitted: false).each do |application|
         ApplicantMailer.deadline_reminder(application).deliver_later
       end

--- a/app/views/admin_mailer/upcoming_event_deadline.text.erb
+++ b/app/views/admin_mailer/upcoming_event_deadline.text.erb
@@ -1,6 +1,6 @@
 Dear Admin,
 
-the deadline for <%= @event.name %> is only two days away!
+the deadline for <%= @event.name %> is approaching soon!
 
 Follow the link below to view details:
 

--- a/app/views/applicant_mailer/deadline_reminder.text.erb
+++ b/app/views/applicant_mailer/deadline_reminder.text.erb
@@ -1,6 +1,6 @@
 Dear <%= @application.name %>,
 
-the deadline for <%= @application.event.name %> is only two days away!
+the deadline for <%= @application.event.name %> is only a few days away!
 
 Do you want to submit your application? Follow the link to further details:
 

--- a/test/mailers/admin_mailer_test.rb
+++ b/test/mailers/admin_mailer_test.rb
@@ -27,7 +27,7 @@ class AdminMailerTest < ActionMailer::TestCase
 
     assert_equal ['info@diversitytickets.org'], email.from
     assert_equal [@admin.email], email.to
-    assert_equal "#{@event.name} deadline in two days.", email.subject
+    assert_equal "#{@event.name} deadline is approaching.", email.subject
   end
 
   test "passed_event_deadline" do

--- a/test/mailers/applicant_mailer_test.rb
+++ b/test/mailers/applicant_mailer_test.rb
@@ -25,6 +25,6 @@ class ApplicantMailerTest < ActionMailer::TestCase
 
     assert_equal ['info@diversitytickets.org'], email.from
     assert_equal [@draft.email], email.to
-    assert_equal "#{@draft.event.name} deadline in two days.", email.subject
+    assert_equal "#{@draft.event.name} deadline is approaching.", email.subject
   end
 end

--- a/test/models/event_test.rb
+++ b/test/models/event_test.rb
@@ -147,7 +147,7 @@ class EventTest < ActiveSupport::TestCase
       make_event(start_date: '2016-07-03', end_date: '2016-07-05', deadline: '2016-06-15')
       make_event(start_date: '2016-06-23', end_date: '2016-06-25', deadline: '2016-06-01')
 
-      assert_equal 1, Event.deadline_in_two_days(DateTime.parse('2016-06-13')).length
+      assert_equal 1, Event.deadline_in_three_days(DateTime.parse('2016-06-12')).length
     end
   end
 

--- a/test/services/deadline_mail_service_test.rb
+++ b/test/services/deadline_mail_service_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 class DeadlineMailServiceTest < ActiveSupport::TestCase
   describe 'sending emails about events with upcoming deadlines to admins'  do
     it 'send emails about right events to the right people' do
-      make_event(deadline: 2.days.from_now, approved: true, name: 'Valid Event')
+      make_event(deadline: 3.days.from_now, approved: true, name: 'Valid Event')
       make_event(deadline: 1.week.from_now)
       make_user(email: 'bad@example.com')
       make_admin(email: 'good@example.com')
@@ -20,8 +20,8 @@ class DeadlineMailServiceTest < ActiveSupport::TestCase
     end
 
     it 'excludes events that are not approved' do
-      make_event(deadline: 2.days.from_now, approved: true, name: 'Valid Event')
-      make_event(deadline: 2.days.from_now, approved: false, name: 'Unapproved Event')
+      make_event(deadline: 3.days.from_now, approved: true, name: 'Valid Event')
+      make_event(deadline: 3.days.from_now, approved: false, name: 'Unapproved Event')
       make_admin
 
       ActionMailer::Base.deliveries.clear
@@ -36,7 +36,7 @@ class DeadlineMailServiceTest < ActiveSupport::TestCase
 
   describe 'sending emails to applicants about upcoming deadlines for their application drafts'  do
     it 'send emails about right events to the right people' do
-      event = make_event(deadline: 2.days.from_now, approved: true, name: 'Valid Event')
+      event = make_event(deadline: 3.days.from_now, approved: true, name: 'Valid Event')
       late_event = make_event(deadline: 1.week.from_now, approved: true, name: 'Late Event')
       make_admin(email: 'bad@example.com')
       user = make_user(email: 'joe@test.com')
@@ -55,8 +55,8 @@ class DeadlineMailServiceTest < ActiveSupport::TestCase
     end
 
     it 'excludes reminders for applications that have been submitted' do
-      event = make_event(deadline: 2.days.from_now, approved: true, name: 'Draft Event')
-      event2 = make_event(deadline: 2.days.from_now, approved: true, name: 'Application Event')
+      event = make_event(deadline: 3.days.from_now, approved: true, name: 'Draft Event')
+      event2 = make_event(deadline: 3.days.from_now, approved: true, name: 'Application Event')
       user = make_user(email: 'joe@test.com')
       make_draft(event, applicant_id: user.id)
       make_application(event2, applicant_id: user.id)


### PR DESCRIPTION
This PR changes the reminder for admins and applicants about upcoming deadlines from 2 days in advance to 3 days in advance. Due to the new feature for individual deadline times during the day we want to ensure that the mailer jobs leave enough time for admins/applicants to act, especially for events with deadlines between midnight and early morning.