### PR TITLE
Csv fix

### DIFF
--- a/app/models/application.rb
+++ b/app/models/application.rb
@@ -27,4 +27,8 @@ class Application < ApplicationRecord
   def self.rejected
     where(status: "rejected")
   end
+
+  def self.active
+    where(deleted: false)
+  end
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -91,7 +91,7 @@ class Event < ApplicationRecord
   def to_csv
     CSV.generate do |csv|
       csv << ["Name", "Email", "Why do you want to attend #{self.name} and what especially do you look forward to learning?", "Please share with us why you're applying for a diversity ticket."]
-      applications.each do |application|
+      applications.active.submitted.each do |application|
         csv << [application.name, application.email, application.attendee_info_1, application.attendee_info_2]
       end
     end


### PR DESCRIPTION
Allows csv download to only show event applications that are active and submitted (excludes all drafts and/or deleted applications).

closes #446 