### PR TITLE
Remove border on default btn class

### DIFF
--- a/app/assets/stylesheets/button.sass
+++ b/app/assets/stylesheets/button.sass
@@ -1,6 +1,7 @@
 .btn
   text-decoration: none
   border-radius: 4px
+  border: none
   padding: 0.5em 0.8em
   font-size: 15px
   color: #ffffff !important


### PR DESCRIPTION
Ohai :wave: 
I noticed the new tag filter (very cool :+1: ) and that the button could be nicer ;)

This willl turn this

![screenshot from 2018-11-20 11-51-53](https://user-images.githubusercontent.com/1006478/48768979-cbad3b00-ecba-11e8-9fe3-ddf714f550d6.png)

into this

![screenshot from 2018-11-20 11-48-43](https://user-images.githubusercontent.com/1006478/48768985-cd76fe80-ecba-11e8-848d-0efabf7a5ed0.png)
