### PR TITLE
[FIX] add missing dot before the translation key

### DIFF
--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -110,7 +110,7 @@
         <%= f.radio_button(:application_process, 'application_by_organizer', class: 'has-dependent') %> <%=t('.application_by_organizer') %>
 
         <div class="form_field indent">
-          <p><%= f.form_field :text_area, :application_link, t('.application_form_link'), placeholder: t('application_form_link_placeholder') %></p>
+          <p><%= f.form_field :text_area, :application_link, t('.application_form_link'), placeholder: t('.application_form_link_placeholder') %></p>
         </div>
 
         <% end %>


### PR DESCRIPTION
Fixes https://github.com/rubymonsters/diversity_ticketing/issues/471

There was a missing dot before the translation key and so rails failed to find it. Adding it back fixes it.