### PR TITLE
[FEAT] add download csv to show event admin page

### DIFF
--- a/app/helpers/admin_events_helper.rb
+++ b/app/helpers/admin_events_helper.rb
@@ -1,2 +1,5 @@
 module AdminEventsHelper
+  def download_csv_link(event)
+    link_to t('.download_csv'), event_admin_path(id: event.id, format: :csv), class: "btn btn-save", title: t('.download_data')
+  end
 end

--- a/app/views/admin_events/index.html.erb
+++ b/app/views/admin_events/index.html.erb
@@ -54,8 +54,7 @@
                     <% end %>
                   </div>
                   <p>
-                    <%= link_to t('.download_csv'), event_admin_path(id: event.id, format: :csv),
-                        class: "btn btn-save", title: t('.download_data')%>
+                    <%= download_csv_link(event) %>
                   </p>
                 </li>
                 <% end %>

--- a/app/views/admin_events/show.html.erb
+++ b/app/views/admin_events/show.html.erb
@@ -93,7 +93,10 @@
     <%= link_to t("delete_event"), event_path(@event.id), method: :delete,
         data: {confirm: t(".are_you_sure")}, class: "btn btn-delete" %>
     <%= link_to t(".edit_event"), edit_event_path(@event.id), class: "btn btn-edit" %>
-    <% unless @event.approved? %>
+    <% if @event.approved? %>
+      <%= link_to t('.download_csv'), event_admin_path(id: @event.id, format: :csv), 
+        class: "btn btn-save", title: t('.download_data') %>
+    <% else %>
       <span class="approve-button">
         <%= form_for :approve,
             url: approve_admin_event_path(@event),

--- a/app/views/admin_events/show.html.erb
+++ b/app/views/admin_events/show.html.erb
@@ -94,8 +94,7 @@
         data: {confirm: t(".are_you_sure")}, class: "btn btn-delete" %>
     <%= link_to t(".edit_event"), edit_event_path(@event.id), class: "btn btn-edit" %>
     <% if @event.approved? %>
-      <%= link_to t('.download_csv'), event_admin_path(id: @event.id, format: :csv), 
-        class: "btn btn-save", title: t('.download_data') %>
+      <%= download_csv_link(@event) %>
     <% else %>
       <span class="approve-button">
         <%= form_for :approve,

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -109,6 +109,8 @@ en:
       are_you_sure: "Are you sure?"
       delete: "Delete"
       delete_event: "Delete event"
+      download_csv: "Download CSV"
+      download_data: "Download data"
       edit_event: "Edit event"
       home_link: "Home"
       organizer_details: "Organizer details"

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -110,6 +110,8 @@ es:
       edit_event: "Editar evento"
       delete: "Borrar"
       delete_event: "Borrar evento"
+      download_csv: "Descargar CSV"
+      download_data: "Descargar datos"
       home_link: "Inicio"
       organizer_details: "Detalles del organizador"
       organizer_email: "Email"


### PR DESCRIPTION
-- add download csv option to admin event show page #463
-- reused the same code to download csv from the index page using a view helper

<img width="512" alt="Screenshot 2019-03-20 at 20 40 32" src="https://user-images.githubusercontent.com/1243626/54714118-8574c500-4b50-11e9-9cf9-2b106e446a6c.png">
