### PR TITLE
Add a plural value to pluralize() calls (fix #476)

### DIFF
--- a/app/views/applications/_form.html.erb
+++ b/app/views/applications/_form.html.erb
@@ -2,7 +2,7 @@
 
   <% if @application.errors.any? %>
     <div class="error">
-      <p><%= pluralize(@application.errors.count, "error") %> stopped this application from being saved:</p>
+      <p><%= pluralize(@application.errors.count, "error", "errors") %> stopped this application from being saved:</p>
       <ul>
         <% @application.errors.messages.each do |field, messages| %>
           <li><%= @application.class.human_attribute_name(field) %> <%= join_messages(messages) %></li>

--- a/app/views/applications/edit.html.erb
+++ b/app/views/applications/edit.html.erb
@@ -4,7 +4,7 @@
 
   <% if @application.errors.any? %>
     <div class="error">
-      <p><%= pluralize(@application.errors.count, "error") %> stopped this application from being saved:</p>
+      <p><%= pluralize(@application.errors.count, "error", "errors") %> stopped this application from being saved:</p>
       <ul>
         <% @application.errors.messages.each do |field, messages| %>
           <li><%= @application.class.human_attribute_name(field) %> <%= join_messages(messages) %></li>

--- a/app/views/applications/show.html.erb
+++ b/app/views/applications/show.html.erb
@@ -51,7 +51,7 @@
 
       <% if @application.errors.any? %>
         <div class="error">
-          <p><%= pluralize(@application.errors.count, "error") %> stopped this application from being saved:</p>
+          <p><%= pluralize(@application.errors.count, "error", "errors") %> stopped this application from being saved:</p>
           <ul>
             <% @application.errors.messages.each do |field, messages| %>
               <li><%= @application.class.human_attribute_name(field) %> <%= join_messages(messages) %></li>

--- a/app/views/drafts/edit.html.erb
+++ b/app/views/drafts/edit.html.erb
@@ -4,7 +4,7 @@
 
   <% if @draft.errors.any? %>
     <div class="error">
-      <p><%= pluralize(@draft.errors.count, "error") %> stopped this draft from being saved:</p>
+      <p><%= pluralize(@draft.errors.count, "error", "errors") %> stopped this draft from being saved:</p>
       <ul>
         <% @draft.errors.messages.each do |field, messages| %>
           <li><%= @draft.class.human_attribute_name(field) %> <%= join_messages(messages) %></li>

--- a/app/views/drafts/show.html.erb
+++ b/app/views/drafts/show.html.erb
@@ -43,7 +43,7 @@
 
     <% if @draft.errors.any? %>
       <div class="error">
-        <p><%= pluralize(@draft.errors.count, "error") %> stopped this application from being saved:</p>
+        <p><%= pluralize(@draft.errors.count, "error", "errors") %> stopped this application from being saved:</p>
         <ul>
           <% @draft.errors.messages.each do |field, messages| %>
             <li><%= @draft.class.human_attribute_name(field) %> <%= join_messages(messages) %></li>

--- a/app/views/events/_application_details.html.erb
+++ b/app/views/events/_application_details.html.erb
@@ -15,7 +15,7 @@
 
   <div class="detail-pair">
     <strong><%= t('.number_tickets') %></strong>
-    <%= pluralize(@event.number_of_tickets, t('.ticket')) %>
+    <%= pluralize(@event.number_of_tickets, t('.ticket'), t('.tickets')) %>
   </div>
 
   <div class="detail-pair">

--- a/app/views/events/edit.html.erb
+++ b/app/views/events/edit.html.erb
@@ -6,7 +6,7 @@
 
 <% if @event.errors.any? %>
   <div class="error">
-    <p><%= pluralize(@event.errors.count, "error") %><%= t('.errors') %> </p>
+    <p><%= pluralize(@event.errors.count, "error", "errors") %><%= t('.errors') %> </p>
 
     <ul>
       <% @event.errors.messages.each do |field, messages| %>

--- a/app/views/events/new.html.erb
+++ b/app/views/events/new.html.erb
@@ -7,7 +7,7 @@
 
 <% if @event.errors.any? %>
   <div class="error">
-    <p><%= pluralize(@event.errors.count, "error") %> <%=t('.errors') %></p>
+    <p><%= pluralize(@event.errors.count, "error", "errors") %> <%=t('.errors') %></p>
 
     <ul>
       <% @event.errors.messages.each do |field, messages| %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -301,6 +301,7 @@ en:
       midnight_utc: "(midnight UTC)"
       number_tickets: "Number of available diversity tickets"
       ticket: "ticket"
+      tickets: "tickets"
       travel: "Travel"
       whats_funded: "What's funded?"
     event:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -301,6 +301,7 @@ es:
       directions_applicants: "Directrices para las/os solicitantes"
       number_tickets: "Número de tickets disponibles"
       ticket: "ticket"
+      tickets: "tickets"
       travel: "Transporte"
       whats_funded: "¿Qué incluye?"
     event:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -301,6 +301,7 @@ fr:
       midnight_utc: "(minuit UTC)"
       number_tickets: "Nombre de billets diversité disponibles"
       ticket: "billet"
+      tickets: "billets"
       travel: "Voyage"
       whats_funded: "Ce qui est financé"
     event:


### PR DESCRIPTION
When using `pluralize()` in views, you need to give the singular and the plural form as arguments or else the pluralization will only happen for english.