### PR TITLE
feat: Order past events by end_date

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -12,7 +12,7 @@ class EventsController < ApplicationController
   end
 
   def index_past
-    @events = EventSearchService.new(params).results.approved.past.active
+    @events = EventSearchService.new(params).results.approved.past.active.order(end_date: :desc)
     @selected_tags = EventSearchService.new(params).selected_tags
   end
 


### PR DESCRIPTION
In past_events_index order events by end_date descending.

closes #289 