### PR TITLE
Fix missing locale variable for %{event_name}

### DIFF
--- a/app/views/applications/edit.html.erb
+++ b/app/views/applications/edit.html.erb
@@ -43,7 +43,7 @@
       <span class="check-label"><%=t('.agree_terms_and_conditions') %></span>
       <% end %>
       <p id="terms-and-conditions">
-        <%= t('.terms_and_conditions_1') %>
+        <%= t('.terms_and_conditions_1', event_name: @event.name)%>
       </p>
       <ul>
         <% if @event.ticket_funded? %>

--- a/app/views/applications/show.html.erb
+++ b/app/views/applications/show.html.erb
@@ -61,7 +61,7 @@
           <span class="check-label"><%=t('.agree_terms_and_conditions') %></span>
           <% end %>
           <p id="terms-and-conditions">
-            <%= t('.terms_and_conditions_1') %>
+            <%= t('.terms_and_conditions_1', event_name: @event.name)%>
           </p>
           <ul>
             <% if @event.ticket_funded? %>

--- a/app/views/drafts/edit.html.erb
+++ b/app/views/drafts/edit.html.erb
@@ -43,7 +43,7 @@
         <span class="check-label"><%=t('.agree_terms_and_conditions') %></span>
       <% end %>
       <p id="terms-and-conditions">
-        <%= t('.terms_and_conditions_1') %>
+        <%= t('.terms_and_conditions_1', event_name: @event.name)%>
       </p>
       <ul>
         <% if @event.ticket_funded? %>

--- a/app/views/drafts/show.html.erb
+++ b/app/views/drafts/show.html.erb
@@ -56,7 +56,7 @@
         <span class="check-label"><%=t('.agree_terms_and_conditions') %></span>
         <% end %>
         <p id="terms-and-conditions">
-          <%= t('.terms_and_conditions_1') %>
+          <%= t('.terms_and_conditions_1', event_name: @event.name)%>
         </p>
         <ul>
           <% if @event.ticket_funded? %>


### PR DESCRIPTION
This fixes the missing locale for event_name in the applications’ T&C’s for:
- applications_show
- applications_edit
- drafts_show
- drafts_edit