### PR TITLE
feat: Change email to diversityticketsorg@gmail.com across app

### DIFF
--- a/app/views/applicant_mailer/application_received.text.erb
+++ b/app/views/applicant_mailer/application_received.text.erb
@@ -4,10 +4,10 @@ thank you for applying for a diversity ticket for <%= @application.event.name %>
 
 We will contact you after the applications are closed and when the winners of the diversity tickets are raffled out. Every conference is different, so we can’t tell you for sure how much the selection process will take; two weeks from the application deadline usually give us enough time to process all applications.
 
-If you have further questions, you can reach us at foundation@travis-ci.org
+If you have further questions, you can reach us at diversityticketsorg@gmail.com
 
 We cross our fingers for you,
 
-The Travis Foundation Team
+The Diversity Tickets Team
 
 —

--- a/app/views/applicant_mailer/deadline_reminder.text.erb
+++ b/app/views/applicant_mailer/deadline_reminder.text.erb
@@ -6,10 +6,10 @@ Do you want to submit your application? Follow the link to further details:
 
 <%= event_application_url(@application.event_id, @application.id, locale: "en") %>
 
-If you have further questions, you can reach us at foundation@travis-ci.org
+If you have further questions, you can reach us at diversityticketsorg@gmail.com
 
 We cross our fingers for you,
 
-The Travis Foundation Team
+The Diversity Tickets Team
 
 —

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -19,7 +19,7 @@
         </h2>
         <h5>
           This number displays the actual amount of tickets given out to applicants
-          and is only visible for the Travis Foundation for statistical purposes.
+          and is only visible for the team of Diversity Tickets for statistical purposes.
         </h5>
         <%= form_for @event, url: event_path(@event), builder: ::FormBuilder do |f| %>
           <%= f.form_field :text_field, :approved_tickets, 'Update final number of approved tickets:' %>

--- a/app/views/home/faq.html.erb
+++ b/app/views/home/faq.html.erb
@@ -57,7 +57,7 @@
   <%= raw t('.why_event_not_approved_answer') %>
 
   <p id="conf_5"><strong><%= t('.how_can_i_add_tags') %></strong></p>
-  <%=raw t('.how_can_i_add_tags_answer', travis_email: '<a href="mailto:foundation@travis-ci.org">foundation@travis-ci.org</a>').html_safe %>
+  <%=raw t('.how_can_i_add_tags_answer', diversity_email: '<a href="mailto:diversityticketsorg@gmail.com">diversityticketsorg@gmail.com</a>').html_safe %>
 
   <p id="conf_6"><strong><%= t('.why_provide_a_link') %></strong></p>
   <%= raw t('.why_provide_a_link_answer') %>
@@ -71,5 +71,5 @@
   <%= raw t('.am_i_eligible_answer') %>
 
   <p id="grant_3"><strong><%= t('.when_find_application_approved_rejected') %></strong></p>
-  <%= raw t('.when_find_application_approved_rejected_answer', travis_mail: 'mail_to "foundation@travis-ci.org"' )%>
+  <%= raw t('.when_find_application_approved_rejected_answer', travis_mail: 'mail_to "diversityticketsorg@gmail.com"' )%>
 </div>

--- a/app/views/home/impressum.html.erb
+++ b/app/views/home/impressum.html.erb
@@ -17,7 +17,7 @@ Rigaer Straße 8</br>
 
 <h3>Kontakt:</h3>
 <p>
-E-Mail: foundation@travis-ci.org</br>
+E-Mail: diversityticketsorg@gmail.com</br>
 URL: https://diversitytickets.org
 </p>
 
@@ -68,7 +68,7 @@ Germany
 
 <h3>Contact Information:</h3>
 <p>
-E-Mail: foundation@travis-ci.org</br>
+E-Mail: diversityticketsorg@gmail.com</br>
 Internet address: https://diversitytickets.org
 </p>
 

--- a/app/views/organizer_mailer/approved_event.text.erb
+++ b/app/views/organizer_mailer/approved_event.text.erb
@@ -4,8 +4,8 @@ Your event <%= @event.name %> has been approved on diversitytickets.org and is n
 
 You have the option of receiving an email reminder to be notified when the number of submitted applications for your event has exceeded the amount of tickets you provide. In order to receive this information, please adjust your email preferences in your account settings to allow us to send you notifications: https://diversitytickets.org/users/<%= @event.organizer_id %>/edit
 
-If you have any more questions, please read the FAQ (https://diversitytickets.org/faq). If you need more help, contact foundation@travis-ci.org.
+If you have any more questions, please read the FAQ (https://diversitytickets.org/faq). If you need more help, contact diversityticketsorg@gmail.com.
 
-The Travis Foundation Team
+The Diversity Tickets Team
 
 -

--- a/app/views/organizer_mailer/submitted_event.text.erb
+++ b/app/views/organizer_mailer/submitted_event.text.erb
@@ -4,8 +4,8 @@ Thank you for submitting your event <%= @event.name %>.
 
 Your event is not yet visible to the public. You will be informed as soon as your event is approved.
 
-If you have any more questions, please read the FAQ (https://diversitytickets.org/faq). If you need more help, contact foundation@travis-ci.org.
+If you have any more questions, please read the FAQ (https://diversitytickets.org/faq). If you need more help, contact diversityticketsorg@gmail.com.
 
-The Travis Foundation Team
+The Diversity Tickets Team
 
 -

--- a/app/views/organizer_mailer/ticket_capacity_reached.text.erb
+++ b/app/views/organizer_mailer/ticket_capacity_reached.text.erb
@@ -6,8 +6,8 @@ Would you like to open up more tickets for <%= @event.name %>?
  -> Go to https://diversitytickets.org/events/<%= @event.id %>/edit to edit the number of available diversity tickets. When you are done make sure to click "Submit changes".
 
 If you have any more questions, please read the FAQ (https://diversitytickets.org/faq).
-If you need more help, contact foundation@travis-ci.org.
+If you need more help, contact diversityticketsorg@gmail.com.
 
-The Travis Foundation Team
+The Diversity Tickets Team
 
 -

--- a/app/views/user_notifications_mailer/new_field_specific_event.text.erb
+++ b/app/views/user_notifications_mailer/new_field_specific_event.text.erb
@@ -2,8 +2,8 @@ Dear <%= @user.name %>,
 
 There is a new event of your interest! You can check it here: <%= event_url(@event.id, locale: "en") %>
 
-If you have any more questions, please read the FAQ (https://diversitytickets.org/faq). If you need more help, contact foundation@travis-ci.org.
+If you have any more questions, please read the FAQ (https://diversitytickets.org/faq). If you need more help, contact diversityticketsorg@gmail.com.
 
-The Travis Foundation Team
+The Diversity Tickets Team
 
 -

--- a/app/views/user_notifications_mailer/new_local_event.text.erb
+++ b/app/views/user_notifications_mailer/new_local_event.text.erb
@@ -2,8 +2,8 @@ Dear <%= @user.name %>,
 
 There is a new event in your country! You can check it here: <%= event_url(@event.id, locale: "en") %>
 
-If you have any more questions, please read the FAQ (https://diversitytickets.org/faq). If you need more help, contact foundation@travis-ci.org.
+If you have any more questions, please read the FAQ (https://diversitytickets.org/faq). If you need more help, contact diversityticketsorg@gmail.com.
 
-The Travis Foundation Team
+The Diversity Tickets Team
 
 -

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -422,7 +422,7 @@ en:
       how_can_i_submit_my_event: "How can I submit my event?"
       how_can_i_submit_my_event_answer: "<p>To submit your event, click on \"Submit Event\" and fill out all the details. Your personal information (name and email) will not be public and is only asked so that we can contact you.</p>"
       how_can_i_add_tags: "How can I add a new tag to my event?"
-      how_can_i_add_tags_answer: "<p>We currently only allow site administrators to add new tags; if you'd like to tag your event with a tag that is currently not available from the list, please drop us a line at %{travis_email}. We will try to process your request as quickly as possible and add your chosen tag to your event submission.</p>"
+      how_can_i_add_tags_answer: "<p>We currently only allow site administrators to add new tags; if you'd like to tag your event with a tag that is currently not available from the list, please drop us a line at %{diversity_email}. We will try to process your request as quickly as possible and add your chosen tag to your event submission.</p>"
       why_provide_a_link: "Why do I have to provide a link when I manage the application and selection myself?"
       why_provide_a_link_short: "Why do I have to provide a link?"
       why_provide_a_link_answer: "When you manage the application and selection process yourself it's important to show applicants (and your community) that you are serious about diversity and inclusion and you are trying to make an effort. A link to a form for the application or a dedicated page on your event page explaining how you will choose from applicants, what you're looking for and why, and what you want to achieve by offering diversity tickets goes a long way."
@@ -496,7 +496,7 @@ en:
       title: "Privacy"
       your_data: "<p>Diversity Tickets uses third-party vendors and hosting partners to provide the necessary hardware, software, networking, storage, and related technology required to run Diversity Tickets. Although Diversity Tickets owns the databases to the Diversity Tickets application, you retain all rights to your data. We will never share your personal data with a third party without your prior authorization, and we will never sell data to third parties. We transfer data with third-parties necessary to our ability to provide our services, all of whom are GDPR-compliant and provide the necessary safeguards required if they are outside of the EU.</p>"
       your_data_title: "Your data"
-      your_rights: "<p>For further information on your rights, to withdraw consent, or to ask for deletion of your data, you can contact us at <a href=\"mailto:foundation@travis-ci.org\">foundation@travis-ci.org</a>.</p>"
+      your_rights: "<p>For further information on your rights, to withdraw consent, or to ask for deletion of your data, you can contact us at <a href=\"mailto:diversityticketsorg@gmail.com\">diversityticketsorg@gmail.com</a>.</p>"
       your_rights_title: "Your rights"
 
   layouts:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -440,7 +440,7 @@ es:
       how_can_i_submit_my_event: "¿Cómo puedo subir un evento?"
       how_can_i_submit_my_event_answer: '<p>Para subir un evento, click en "Subir evento" e incluye todos los detalles. Tu información personal (nombre y email) no serán visibles públicamente y sólo son necesarias para que podamos contactarte.</p>'
       how_can_i_add_tags: "¿Cómo puedo añadir un nuevo tag a mi evento?"
-      how_can_i_add_tags_answer: "<p>Sólo los administradores de la página pueden añadir nuevas tags; si te gustaría añadir un tag que no está disponible a tu evento, envíanos un email: %{travis_email}. Intentaremos procesar tu petición tan rápido como sea posible y añadir el tag que has elegido a tu evento. </p>"
+      how_can_i_add_tags_answer: "<p>Sólo los administradores de la página pueden añadir nuevas tags; si te gustaría añadir un tag que no está disponible a tu evento, envíanos un email: %{diversity_email}. Intentaremos procesar tu petición tan rápido como sea posible y añadir el tag que has elegido a tu evento. </p>"
       why_provide_a_link: "¿Por qué tengo que ofrecer un enlace cuando administro la aplicación y la selección usted mismo?"
       why_provide_a_link_short: "¿Por qué tengo que ofrecer un enlace?"
       why_provide_a_link_answer: "Cuando usted mismo administre el proceso de solicitud y selección, es importante mostrar a los solicitantes (y a su comunidad) que se toma en serio la diversidad y la inclusión y sobre todo que está tratando de hacer un esfuerzo. Un enlace a un formulario para la solicitud o una página dedicada en la página de su evento que explica cómo elegirá a los solicitantes, qué está buscando y por qué, y qué quiere lograr al ofrecer boletos de diversidad supondrá un gran avance."

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -422,7 +422,7 @@ fr:
       how_can_i_submit_my_event: "Comment puis-je proposer mon événement ?"
       how_can_i_submit_my_event_answer: "<p>Pour soumettre votre événement, cliquez sur \"Soumettre un événement\" et remplissez tous les détails. Vos informations personnelles (nom et email) ne seront pas rendues publiques et ne sont demandées que dans l'objectif de vous contacter.</p>"
       how_can_i_add_tags: "Comment puis-je ajouter une nouvelle étiquette à mon événement ?"
-      how_can_i_add_tags_answer: "<p>Nous n'autorisons actuellement que les administrateurs du site à ajouter de nouvelles étiquettes ; si vous souhaitez marquer votre événement avec une étiquette qui n'est actuellement pas disponible dans la liste, veuillez nous envoyer un message à %{travis_email}. Nous nous efforcerons de traiter votre demande le plus rapidement possible et d'ajouter l'étiquette que vous avez choisie à votre dossier de soumission d'événement.</p>"
+      how_can_i_add_tags_answer: "<p>Nous n'autorisons actuellement que les administrateurs du site à ajouter de nouvelles étiquettes ; si vous souhaitez marquer votre événement avec une étiquette qui n'est actuellement pas disponible dans la liste, veuillez nous envoyer un message à %{diversity_email}. Nous nous efforcerons de traiter votre demande le plus rapidement possible et d'ajouter l'étiquette que vous avez choisie à votre dossier de soumission d'événement.</p>"
       why_provide_a_link: ""
       why_provide_a_link_short: ""
       why_provide_a_link_answer: ""


### PR DESCRIPTION
This PR exchanges foundation@travis-ci.org for diversityticketsorg@gmail.com in mailers and all user communication (Except for the "About" page)

Also:
- Email messages are signed with "The Diversity Tickets Team" now instead of "The Travis Foundation Team"
- On events_show view for admins and organizers "Travis Foundation team" is exchanged for "team of Diversity Tickets" in explanatory text for number of distributed tickets (h5).