### PR TITLE
Application process toggle

### DIFF
--- a/app/controllers/admin_events_controller.rb
+++ b/app/controllers/admin_events_controller.rb
@@ -7,6 +7,7 @@ class AdminEventsController < ApplicationController
 
   #Admin page view with all submitted events and admin statistics:
   def index
+    @application_process_options_handler = ApplicationProcessOptionsHandler.find(1)
     @events = Event.all
     @new_users = User.all.created_last_30_days
     @total_organizers = Event.all.total_organizers

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -23,5 +23,10 @@ class ApplicationController < ActionController::Base
     signed_in? && current_user.admin?
   end
 
+  def selection_by_dt_enabled?
+    ApplicationProcessOptionsHandler.first.selection_by_dt_enabled
+  end
+
   helper_method :admin_user?
+  helper_method :selection_by_dt_enabled?
 end

--- a/app/controllers/application_process_options_handlers_controller.rb
+++ b/app/controllers/application_process_options_handlers_controller.rb
@@ -1,0 +1,20 @@
+#This controller manages the enabling and disabling of selection process by DT
+class ApplicationProcessOptionsHandlersController < ApplicationController
+  before_action :require_admin
+
+  def update
+    @application_process_options_handler = ApplicationProcessOptionsHandler.find(1)
+    if @application_process_options_handler.update(application_process_options_handler_params)
+      redirect_to admin_url,
+      notice: "Application process options successfully updated"
+    else
+      redirect_to admin_url, notice: "Application process options could not be updated. Please try again."
+    end
+  end
+
+  private
+
+  def application_process_options_handler_params
+    params.require(:application_process_options_handler).permit(:selection_by_dt_enabled)
+  end
+end

--- a/app/models/application_process_options_handler.rb
+++ b/app/models/application_process_options_handler.rb
@@ -1,0 +1,2 @@
+class ApplicationProcessOptionsHandler < ApplicationRecord
+end

--- a/app/views/admin_events/index.html.erb
+++ b/app/views/admin_events/index.html.erb
@@ -14,6 +14,20 @@
     class: "btn btn-save"%>
 </p>
 
+
+<div class="box">
+  <h2>Manage "Selection by Diversity Tickets"</h2>
+  <%= form_for @application_process_options_handler, url: update_process_path do |form| %>
+    <%= form.check_box :selection_by_dt_enabled, value: selection_by_dt_enabled?  %>
+      Enable selection by Diversity Tickets?
+    <div class="submit-field">
+      <%= form.submit(class: "btn btn-save", value: 'Save', data: {
+        confirm: selection_by_dt_enabled? ? 'Are you sure you want to disable selection by Diversity Tickets?' : 'Are you sure you want to enable selection by Diversity Tickets?'
+      }) %>
+    </div>
+  <% end %>
+</div>
+
 <% @categorized_events.each do |heading, events| %>
   <div class="box">
     <h2><%= heading %></h2>

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -86,8 +86,10 @@
     <section class="box">
       <h2 class="box-title"><%= t('.application_selection') %></h2>
       <div class="form_field">
-        <%= label_tag do %>
-          <%= f.radio_button(:application_process, 'selection_by_travis', checked: 'checked') %> <%= t('.selection_by_travis')%>
+        <% if selection_by_dt_enabled? %>
+          <%= label_tag do %>
+            <%= f.radio_button(:application_process, 'selection_by_travis', checked: 'checked') %> <%= t('.selection_by_travis')%>
+          <% end %>
         <% end %>
 
         <%= label_tag do %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -53,6 +53,8 @@ Rails.application.routes.draw do
     post 'users/:id/delete', to: 'users#delete_account', as: :delete_account
     patch '/events/:event_id/drafts/:id/submit', to: 'drafts#submit', as: :submit_draft
 
+    patch '/admin', to: 'application_process_options_handlers#update', as: :update_process
+
     root 'home#home'
   end
 end

--- a/db/migrate/20190926090956_create_application_process_options_handler.rb
+++ b/db/migrate/20190926090956_create_application_process_options_handler.rb
@@ -1,0 +1,7 @@
+class CreateApplicationProcessOptionsHandler < ActiveRecord::Migration[5.2]
+  def change
+    create_table :application_process_options_handlers do |t|
+      t.boolean :selection_by_dt_enabled, default: true, null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,14 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_08_26_092342) do
+ActiveRecord::Schema.define(version: 2019_09_26_090956) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "application_process_options_handlers", force: :cascade do |t|
+    t.boolean "selection_by_dt_enabled", default: true, null: false
+  end
 
   create_table "applications", id: :serial, force: :cascade do |t|
     t.string "name"

--- a/test/controllers/admin_events_controller_test.rb
+++ b/test/controllers/admin_events_controller_test.rb
@@ -1,6 +1,10 @@
 require 'test_helper'
 
 class AdminEventsControllerTest < ActionController::TestCase
+  before do
+    make_application_process_options_handler
+  end
+  
   describe '#index' do
     it 'protect admin index from anonymous visitors, redirects to sign in' do
       get :index

--- a/test/controllers/admin_events_controller_test.rb
+++ b/test/controllers/admin_events_controller_test.rb
@@ -4,7 +4,7 @@ class AdminEventsControllerTest < ActionController::TestCase
   before do
     make_application_process_options_handler
   end
-  
+
   describe '#index' do
     it 'protect admin index from anonymous visitors, redirects to sign in' do
       get :index

--- a/test/controllers/application_process_options_handlers_controller_test.rb
+++ b/test/controllers/application_process_options_handlers_controller_test.rb
@@ -1,0 +1,23 @@
+require 'test_helper'
+
+class ApplicationProcessOptionsHandlersControllerTest < ActionController::TestCase
+  before do
+    @apoh = make_application_process_options_handler
+  end
+
+  describe '#update' do
+    it 'updates application_process_option selection_by_dt correctly' do
+      user = make_user(admin: true)
+      sign_in_as(user)
+
+      assert_equal(true, @apoh.selection_by_dt_enabled)
+
+      patch :update, params: { application_process_options_handler: {selection_by_dt_enabled: 0} }
+      assert_response :redirect
+
+      @apoh.reload
+
+      assert_equal(false, @apoh.selection_by_dt_enabled)
+    end
+  end
+end

--- a/test/controllers/events_controller_test.rb
+++ b/test/controllers/events_controller_test.rb
@@ -1,6 +1,10 @@
 require 'test_helper'
 
 class EventsControllerTest < ActionController::TestCase
+  before do
+    make_application_process_options_handler
+  end
+  
   describe '#create' do
     it 'successfully creates event and sends etest' do
       admin_user = make_admin

--- a/test/integration/admin_event_details_test.rb
+++ b/test/integration/admin_event_details_test.rb
@@ -4,6 +4,7 @@ include ApplicationHelper
 feature 'Admin Event Details' do
 
   def setup
+    make_application_process_options_handler
     @admin = make_admin
     @event = make_event
     @application_1 = make_application(@event, name: 'Peter', status: 'pending')

--- a/test/integration/admin_events_test.rb
+++ b/test/integration/admin_events_test.rb
@@ -1,6 +1,10 @@
 require 'test_helper'
 
 feature 'Admin Events' do
+  before do
+    make_application_process_options_handler
+  end
+
   scenario 'Approve and unapprove event' do
     click_link 'Admin'
 

--- a/test/integration/sign_in_test.rb
+++ b/test/integration/sign_in_test.rb
@@ -2,6 +2,7 @@ require 'test_helper'
 
 feature 'User Sign In' do
   def setup
+    make_application_process_options_handler
     @user = make_user
     @admin = make_admin
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -152,6 +152,15 @@ class ActiveSupport::TestCase
     Tag.create!(tag_params)
   end
 
+  def make_application_process_options_handler(application_process_options_handler_params = {})
+    defaults = {
+      id: 1,
+      selection_by_dt_enabled: true
+    }
+    application_process_options_handler_params = defaults.merge(application_process_options_handler_params)
+    ApplicationProcessOptionsHandler.create!(application_process_options_handler_params)
+  end
+
   # Add more helper methods to be used by all tests here...
 end
 


### PR DESCRIPTION
This PR adds the option to disable/enable "selction by travis" (selection by diversity tickets)

- [x] Displays a checkbox on Admin Page to manage Application Process Options
- If ApplicationProcessOptionsHandler.selection_by_dt_enabled is false, the event form on events_new view does not show the option to select "selection_by_travis"
- Default is true
